### PR TITLE
WIP: Update Gulp version & Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,45 @@
 This repository contains the activities and assignments required to complete the final course of the Front End Certificate program. All assignment submissions and quizzes/discussions will be done through [Canvas](https://canvas.uw.edu/).
 
 ## Course Setup
-Follow these steps to get your initial setup started
 
-### Recommended Tools
+### Optional Development Tools
+
+These are tools that can be installed on your computer, if they look useful to you.
+
 - [Visual Studio Code](https://code.visualstudio.com/) - Editor/IDE
 - [Hyper Terminal](https://hyper.is/) - Modern Terminal
-- [Oh My Zsh](https://ohmyz.sh/) - Zsh framework
 - [Adobe XD](https://www.adobe.com/products/xd.html) - Design Tool
 
-### Required Tools (by end of course)
-- [NodeJS/npm](https://nodejs.org/en/)
-- [Gulp](https://gulpjs.com/)
-- [Sass](https://sass-lang.com/documentation)
-- [Bootstrap 4](https://getbootstrap.com/)
-- [Vue](https://vuejs.org/)
-- [Vue Devtools](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd?hl=en)
-- [Yarn](https://yarnpkg.com/lang/en/docs/install/)
-- [Nuxt](https://nuxtjs.org/)
+### Initial Setup
 
+The only tool you *must* install locally (on your computer) to get started is Node/npm. Visit [the Node homepage](https://nodejs.org/) and download the latest stable version. This will be the one labeled "Recommended for most users". Follow instructions to install it.
+
+Npm stands for "Node Package Manager". We downloaded Node, but we won't be using it to write server-side javascript. We'll just be using npm to manage the javascript packages our projects will use. Each "activity" and "assignment" directory in this repo is a project.
+
+We will be using npm from the terminal. When instructions say "from within a project", it means that you should navigate to a project (like "html300/lesson03/activity") before running the command.
+
+Npm can be used to install javascript packages in a single project. This is the default behavior when `npm install package-name-here` is run. This is the way we will be using it in this course. It can also install packages on your computer (referred to as "global" installation, because they are then available outside of projects). This is done by including the `-g` flag when installing, like `npm install -g package-name-here`. We will not be using this functionality in this course.
+
+Global installation can cause compatibility problems, and is no longer recommended. Instead, when you need to run a command to a specific Node package (as we will with Gulp), we can use the `npx` prefix. This will execute the command with the version of that package installed in the project.
+
+#### Gulp  
+
+We will be using Gulp as our main build tool in this course. There is no need to install it on your computer, we will only be using it with the `npx` prefix as explained above.  
+
+After lesson01, each activity and assignment will be run by starting a Gulp task, and then visiting the URL that is made available. Gulp will pay attention to changes in your Sass and HTML files, and update what is shown in the browser when any changes are saved. It will automatically convert Sass code to CSS.
+
+Each activity and assignment is already configured with a Gulpfile that defines the tasks. You will not need to edit these in any way. __Your interaction with Gulp will be limited to running `npx gulp` from within a project directory to start up a server.__
+
+If you're interested, visit [Gulp's documentation](https://gulpjs.com) to learn more about how the tool works. This is strictly optional.
 
 ### Course Final Project Setup
+
 - Create a new repository that will hold your final course project, name it something appropriate for what it will do (e.g. "WeatherTracker", "MovieGuide", etc)
 - Viewing that new repo on Github, click on the `Settings` tab at the top right, then the `Collaborators` tab on the left. Add `cherimarie` (https://github.com/cherimarie) and `madeste` (https://github.com/madeste) as collaborators.
 - For assignment 01 you will create a `documents` folder in the root with a `.txt` or `.md` file within, containing the course proposal
 - As the course progresses, work for the course final project will be done in the new repo
 
-*The rest of these instructions are for working with this html300 repo* 
+*The rest of these instructions are for working with this html300 repo*
 
 ### html300 Course Repo Setup
 - Within *this* html300 repo, click the `fork` button the the top right to fork a copy to your personal GitHub account
@@ -36,7 +49,7 @@ Follow these steps to get your initial setup started
 - Clone the fork to your local machine
 
 ### Adding the Upstream to your Fork
-- Navigate to your fork's root folder in terminal (e.g. `cd ~/Sites/uw/html300`) 
+- Navigate to your fork's root folder in terminal (e.g. `cd ~/Sites/uw/html300`)
 - Make sure you are on your master branch, `git checkout master`
 - Add the upstream repository as a remote connection `git remote add upstream git@github.com:UWFront-End-Cert/html300.git`
 - Verify with `git remote -v`, should have both `origin` and `upstream`
@@ -51,8 +64,8 @@ Follow these steps to get your initial setup started
 - You shouldn't run into conflicts, but if you get errors or conflicts, you can work this guide to resolve or talk to your instructor for help https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/resolving-a-merge-conflict-using-the-command-line
 
 ## Per Lesson Workflow
-- Start by checking out your local master branch and fetching/merging upstream at the beginning of each module so you know you're up to date
-- From the master branch, create a branch for the lesson's assignment. Keep these branches all named consistently, like "lesson1", "lesson2", etc. 
+- Start by checking out your local master branch and fetching/merging upstream at the beginning of each lesson module so you know you're up to date
+- From the master branch, create a branch for the lesson's assignment. Keep these branches all named consistently, like "lesson1", "lesson2", etc.
 ```
 # Fetch and merge upstream master to your local master branch
 $ git checkout master
@@ -66,7 +79,7 @@ $ git checkout -b lesson3
 - The `assignment` folder will have the starter files and instructions required to complete
 - Once completed, open a new Pull Request. Within the PR, set the base to be YOUR forked master branch, and the compare branch is  that lesson's assignment branch
 - In the Reviewer's section, click into the box and add `cherimarie` and `madeste` as reviewers - note you will have needed to invite us as collaborators to your fork first
-- Now, do NOT merge or close the Pull Request -- just add us as reviewers 
+- Now, do NOT merge or close the Pull Request -- just add us as reviewers
 - Copy the direct link to the pull request page, and paste that into the submission box in Canvas
 
 ### Assignments
@@ -77,9 +90,22 @@ $ git checkout -b lesson3
 ### Quizzes
 - Each week there will be a quiz available to take, please flag up any issues if questions aren't being assessed correctly
 
-### Resources
+### Resources: Libraries
+
+These are libraries that will be used in assignments and activities. When you're ready, use these links to documentation to learn more about them.
+
+- [NodeJS/npm](https://nodejs.org/en/)
+- [Gulp](https://gulpjs.com/)
+- [Sass](https://sass-lang.com/documentation)
+- [Bootstrap 4](https://getbootstrap.com/)
+- [Vue](https://vuejs.org/)
+- [Vue Devtools](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd?hl=en)
+- [Nuxt](https://nuxtjs.org/)
+
+### Other Resources
+
 - [Git Resources](https://try.github.io/)
-- [Learn Branching](https://learngitbranching.js.org/?locale=en_US)
+- [Learn Git Branching](https://learngitbranching.js.org/?locale=en_US)
 - [Exploring ES6](https://exploringjs.com/es6/)
 - [You Don't Know JS](https://github.com/getify/You-Dont-Know-JS)
 - [Array Explorer](https://sdras.github.io/array-explorer/)

--- a/lesson02/activity/gulpfile.js
+++ b/lesson02/activity/gulpfile.js
@@ -1,14 +1,12 @@
-var gulp = require('gulp'),
+const {dest, series, src, watch} = require('gulp'),
     sass = require('gulp-sass'),
     autoprefix = require('gulp-autoprefixer'),
-    watch = require('gulp-watch'),
     plumber = require('gulp-plumber'),
     gutil = require('gulp-util'),
-    minifycss = require('gulp-minify-css'),
-    browserSync = require('browser-sync').create();
+    browserSync = require('browser-sync').create()
 
-gulp.task('sass', function() {
-    gulp.src('css/*.scss')
+function compileSass() {
+    return src('css/*.scss')
         .pipe(plumber())
         .pipe(sass())
         .pipe(
@@ -16,23 +14,19 @@ gulp.task('sass', function() {
                 browsers: ['> .5%'],
             })
         )
-        .pipe(minifycss({ compatibility: 'ie8' }))
-        .pipe(gulp.dest('css/'))
+        .pipe(dest('css/'))
         .pipe(browserSync.stream());
-});
+}
 
-gulp.task('watch', function() {
-    gulp.watch('css/*.scss', ['sass']);
-    gulp.watch('*.html').on('change', browserSync.reload);
-});
-
-gulp.task('browser-sync', function() {
+function browserSyncs() {
     browserSync.init({
         notify: false,
         server: {
             baseDir: './',
         },
-    });
-});
+    })
+    watch(['css/*.scss']).on('change', compileSass)
+    watch(['*.html']).on('change', browserSync.reload)
+}
 
-gulp.task('default', ['watch', 'browser-sync']);
+exports.default = browserSyncs

--- a/lesson02/activity/package-lock.json
+++ b/lesson02/activity/package-lock.json
@@ -131,6 +131,15 @@
                 }
             }
         },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "dev": true,
+            "requires": {
+                "buffer-equal": "^1.0.0"
+            }
+        },
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -159,11 +168,29 @@
             "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
             "dev": true
         },
+        "arr-filter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+            "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
+        },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
+        },
+        "arr-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+            "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
         },
         "arr-union": {
             "version": "3.1.0",
@@ -189,11 +216,65 @@
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
+        "array-initial": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+            "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+            "dev": true,
+            "requires": {
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "array-last": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+            "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+            "dev": true,
+            "requires": {
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
         "array-slice": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
             "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
             "dev": true
+        },
+        "array-sort": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+            "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+            "dev": true,
+            "requires": {
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -240,6 +321,18 @@
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
+        "async-done": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+            "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^2.0.0",
+                "stream-exhaust": "^1.0.1"
+            }
+        },
         "async-each": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -263,6 +356,15 @@
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
             "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
+        },
+        "async-settle": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+            "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+            "dev": true,
+            "requires": {
+                "async-done": "^1.2.2"
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -310,6 +412,23 @@
             "requires": {
                 "follow-redirects": "^1.2.5",
                 "is-buffer": "^1.1.5"
+            }
+        },
+        "bach": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+            "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+            "dev": true,
+            "requires": {
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "backo2": {
@@ -591,6 +710,18 @@
             "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
             "dev": true
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
         "bufferstreams": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.0.1.tgz",
@@ -824,6 +955,28 @@
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
+        "collection-map": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+            "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+            "dev": true,
+            "requires": {
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -894,6 +1047,18 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
         "connect": {
             "version": "3.6.6",
             "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -929,6 +1094,15 @@
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -940,6 +1114,16 @@
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
+        },
+        "copy-props": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+            "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+            "dev": true,
+            "requires": {
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -964,6 +1148,16 @@
             "dev": true,
             "requires": {
                 "array-find-index": "^1.0.1"
+            }
+        },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
             }
         },
         "dashdash": {
@@ -1002,13 +1196,36 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
-        "defaults": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+        "default-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+            "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "clone": "^1.0.2"
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "default-resolution": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+            "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -1070,12 +1287,6 @@
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
         },
-        "deprecated": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-            "dev": true
-        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1129,6 +1340,28 @@
                 }
             }
         },
+        "duplexify": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "each-props": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+            "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
+            }
+        },
         "easy-extender": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
@@ -1176,23 +1409,12 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-            "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
             "requires": {
-                "once": "~1.3.0"
-            },
-            "dependencies": {
-                "once": {
-                    "version": "1.3.3",
-                    "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                    "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                    "dev": true,
-                    "requires": {
-                        "wrappy": "1"
-                    }
-                }
+                "once": "^1.4.0"
             }
         },
         "engine.io": {
@@ -1261,6 +1483,50 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -1395,6 +1661,23 @@
             "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -1574,12 +1857,6 @@
                 }
             }
         },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-            "dev": true
-        },
         "find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -1591,26 +1868,17 @@
             }
         },
         "findup-sync": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+            "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
             "dev": true,
             "requires": {
                 "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
+                "is-glob": "^4.0.0",
                 "micromatch": "^3.0.4",
                 "resolve-dir": "^1.0.1"
             },
             "dependencies": {
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -1647,17 +1915,21 @@
                 "parse-filepath": "^1.0.1"
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
         "flagged-respawn": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
             "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
             "dev": true
+        },
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
+            }
         },
         "follow-redirects": {
             "version": "1.7.0",
@@ -1743,6 +2015,16 @@
                 "universalify": "^0.1.0"
             }
         },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1769,7 +2051,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -1790,12 +2073,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1810,17 +2095,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1937,7 +2225,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1949,6 +2238,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1963,6 +2253,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1970,12 +2261,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -1994,6 +2287,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2074,7 +2368,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2086,6 +2381,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2171,7 +2467,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2207,6 +2504,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2226,6 +2524,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2269,12 +2568,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -2289,6 +2590,12 @@
                 "mkdirp": ">=0.5 0",
                 "rimraf": "2"
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "gauge": {
             "version": "2.7.4",
@@ -2422,159 +2729,35 @@
             }
         },
         "glob-stream": {
-            "version": "3.1.18",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "4.5.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                    "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^2.0.1",
-                        "once": "^1.3.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+            "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
             "dev": true,
             "requires": {
-                "gaze": "^0.5.1"
-            },
-            "dependencies": {
-                "gaze": {
-                    "version": "0.5.2",
-                    "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-                    "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-                    "dev": true,
-                    "requires": {
-                        "globule": "~0.1.0"
-                    }
-                },
-                "glob": {
-                    "version": "3.1.21",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
-                    }
-                },
-                "globule": {
-                    "version": "0.1.0",
-                    "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                    "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-                    "dev": true,
-                    "requires": {
-                        "glob": "~3.1.21",
-                        "lodash": "~1.0.1",
-                        "minimatch": "~0.2.11"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-                    "dev": true
-                },
-                "inherits": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                    "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-                    "dev": true
-                },
-                "lru-cache": {
-                    "version": "2.7.3",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                    "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "0.2.14",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
-                    }
-                }
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "dev": true,
-            "requires": {
-                "find-index": "^0.1.1"
+                "anymatch": "^2.0.0",
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "is-negated-glob": "^1.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
@@ -2634,31 +2817,72 @@
             "dev": true
         },
         "gulp": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-            "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+            "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
+                "glob-watcher": "^5.0.3",
+                "gulp-cli": "^2.2.0",
+                "undertaker": "^1.2.1",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-                    "dev": true
+                "gulp-cli": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+                    "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^3.1.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
                 }
             }
         },
@@ -2996,6 +3220,12 @@
                 "sparkles": "^1.0.0"
             }
         },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
+        },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3305,6 +3535,12 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+            "dev": true
+        },
         "is-number": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3385,6 +3621,12 @@
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
+        "is-valid-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+            "dev": true
+        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3445,6 +3687,12 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3472,11 +3720,36 @@
                 "verror": "1.10.0"
             }
         },
+        "just-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+            "dev": true
+        },
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
             "dev": true
+        },
+        "last-run": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+            "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+            "dev": true,
+            "requires": {
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.5"
+            }
         },
         "lcid": {
             "version": "1.0.0",
@@ -3487,14 +3760,23 @@
                 "invert-kv": "^1.0.0"
             }
         },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "dev": true,
+            "requires": {
+                "flush-write-stream": "^1.0.2"
+            }
+        },
         "liftoff": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+            "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
             "dev": true,
             "requires": {
                 "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
+                "findup-sync": "^3.0.0",
                 "fined": "^1.0.1",
                 "flagged-respawn": "^1.0.0",
                 "is-plain-object": "^2.0.4",
@@ -3759,6 +4041,62 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "matchdep": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+            "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+            "dev": true,
+            "requires": {
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
+                "stack-trace": "0.0.10"
+            },
+            "dependencies": {
+                "findup-sync": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+                    "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "dev": true,
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^3.1.0",
+                        "micromatch": "^3.0.4",
+                        "resolve-dir": "^1.0.1"
+                    }
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                }
+            }
+        },
         "math-random": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
@@ -3977,6 +4315,12 @@
                 "duplexer2": "0.0.2"
             }
         },
+        "mute-stdout": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+            "dev": true
+        },
         "nan": {
             "version": "2.12.1",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
@@ -4003,16 +4347,16 @@
                 "to-regex": "^3.0.1"
             }
         },
-        "natives": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-            "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-            "dev": true
-        },
         "negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
         "node-gyp": {
@@ -4121,6 +4465,15 @@
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
         },
+        "now-and-later": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+            "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.2"
+            }
+        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -4194,6 +4547,12 @@
                 }
             }
         },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
         "object-path": {
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
@@ -4207,6 +4566,18 @@
             "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -4272,6 +4643,27 @@
                 "isobject": "^3.0.1"
             }
         },
+        "object.reduce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+            "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "on-finished": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4305,22 +4697,14 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "orchestrator": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+        "ordered-read-streams": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
+                "readable-stream": "^2.0.1"
             }
-        },
-        "ordered-read-streams": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-            "dev": true
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -4687,6 +5071,27 @@
             "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
         },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
+        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -4852,6 +5257,27 @@
                 "safe-regex": "^1.1.0"
             }
         },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "dev": true,
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4884,6 +5310,17 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
             "dev": true
+        },
+        "replace-homedir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+            "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
+            }
         },
         "request": {
             "version": "2.88.0",
@@ -4956,6 +5393,15 @@
             "requires": {
                 "expand-tilde": "^2.0.0",
                 "global-modules": "^1.0.0"
+            }
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
+            "requires": {
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -5107,6 +5553,15 @@
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
             "dev": true
         },
+        "semver-greatest-satisfied-range": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+            "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+            "dev": true,
+            "requires": {
+                "sver-compat": "^1.5.0"
+            }
+        },
         "send": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -5162,12 +5617,6 @@
                     "dev": true
                 }
             }
-        },
-        "sequencify": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-            "dev": true
         },
         "serve-index": {
             "version": "1.9.1",
@@ -5270,12 +5719,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-            "dev": true
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
             "dev": true
         },
         "signal-exit": {
@@ -5613,6 +6056,12 @@
                 "tweetnacl": "~0.14.0"
             }
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -5649,10 +6098,16 @@
                 "readable-stream": "^2.0.1"
             }
         },
-        "stream-consume": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-            "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
+        "stream-exhaust": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+            "dev": true
+        },
+        "stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
         "stream-throttle": {
@@ -5739,6 +6194,16 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "sver-compat": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+            "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "symbol-observable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -5776,13 +6241,14 @@
                 "xtend": "~4.0.1"
             }
         },
-        "tildify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+        "through2-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -5790,6 +6256,16 @@
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
             "dev": true
+        },
+        "to-absolute-glob": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+            "dev": true,
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
+            }
         },
         "to-array": {
             "version": "0.1.4",
@@ -5837,6 +6313,15 @@
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
+            }
+        },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.3"
             }
         },
         "toidentifier": {
@@ -5893,6 +6378,18 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
         "ua-parser-js": {
             "version": "0.7.17",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -5909,6 +6406,29 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
+        },
+        "undertaker": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+            "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
+            }
+        },
+        "undertaker-registry": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
             "dev": true
         },
         "union-value": {
@@ -5947,10 +6467,14 @@
             }
         },
         "unique-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-            "dev": true
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
+            }
         },
         "universalify": {
             "version": "0.1.2",
@@ -6037,12 +6561,6 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
-        "user-home": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-            "dev": true
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6062,12 +6580,12 @@
             "dev": true
         },
         "v8flags": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+            "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
             "dev": true,
             "requires": {
-                "user-home": "^1.1.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -6079,6 +6597,12 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -6139,88 +6663,109 @@
             }
         },
         "vinyl-fs": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
                     "dev": true
                 },
-                "graceful-fs": {
-                    "version": "3.0.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-                    "dev": true,
-                    "requires": {
-                        "natives": "^1.1.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "strip-bom": {
+                "clone-stats": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-                    "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-                    "dev": true,
-                    "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "is-utf8": "^0.2.0"
-                    }
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
                 },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
                 },
                 "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }

--- a/lesson02/activity/package.json
+++ b/lesson02/activity/package.json
@@ -10,7 +10,7 @@
     "license": "ISC",
     "devDependencies": {
         "browser-sync": "^2.26.5",
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.2",
         "gulp-autoprefixer": "^6.1.0",
         "gulp-minify-css": "^1.2.4",
         "gulp-plumber": "^1.2.0",

--- a/lesson02/assignment/gulpfile.js
+++ b/lesson02/assignment/gulpfile.js
@@ -1,14 +1,12 @@
-var gulp = require('gulp'),
+const {dest, series, src, watch} = require('gulp'),
     sass = require('gulp-sass'),
     autoprefix = require('gulp-autoprefixer'),
-    watch = require('gulp-watch'),
     plumber = require('gulp-plumber'),
     gutil = require('gulp-util'),
-    minifycss = require('gulp-minify-css'),
-    browserSync = require('browser-sync').create();
+    browserSync = require('browser-sync').create()
 
-gulp.task('sass', function() {
-    gulp.src('css/*.scss')
+function compileSass() {
+    return src('css/*.scss')
         .pipe(plumber())
         .pipe(sass())
         .pipe(
@@ -16,23 +14,19 @@ gulp.task('sass', function() {
                 browsers: ['> .5%'],
             })
         )
-        .pipe(minifycss({ compatibility: 'ie8' }))
-        .pipe(gulp.dest('css/'))
+        .pipe(dest('css/'))
         .pipe(browserSync.stream());
-});
+}
 
-gulp.task('watch', function() {
-    gulp.watch('css/*.scss', ['sass']);
-    gulp.watch('*.html').on('change', browserSync.reload);
-});
-
-gulp.task('browser-sync', function() {
+function browserSyncs() {
     browserSync.init({
         notify: false,
         server: {
             baseDir: './',
         },
-    });
-});
+    })
+    watch(['css/*.scss']).on('change', compileSass)
+    watch(['*.html']).on('change', browserSync.reload)
+}
 
-gulp.task('default', ['watch', 'browser-sync']);
+exports.default = browserSyncs

--- a/lesson02/assignment/package-lock.json
+++ b/lesson02/assignment/package-lock.json
@@ -131,6 +131,15 @@
                 }
             }
         },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "dev": true,
+            "requires": {
+                "buffer-equal": "^1.0.0"
+            }
+        },
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -159,11 +168,29 @@
             "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
             "dev": true
         },
+        "arr-filter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+            "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
+        },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
+        },
+        "arr-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+            "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
         },
         "arr-union": {
             "version": "3.1.0",
@@ -189,11 +216,65 @@
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
+        "array-initial": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+            "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+            "dev": true,
+            "requires": {
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "array-last": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+            "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+            "dev": true,
+            "requires": {
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
         "array-slice": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
             "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
             "dev": true
+        },
+        "array-sort": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+            "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+            "dev": true,
+            "requires": {
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -240,6 +321,18 @@
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
+        "async-done": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+            "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^2.0.0",
+                "stream-exhaust": "^1.0.1"
+            }
+        },
         "async-each": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -263,6 +356,15 @@
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
             "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
+        },
+        "async-settle": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+            "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+            "dev": true,
+            "requires": {
+                "async-done": "^1.2.2"
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -310,6 +412,23 @@
             "requires": {
                 "follow-redirects": "^1.2.5",
                 "is-buffer": "^1.1.5"
+            }
+        },
+        "bach": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+            "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+            "dev": true,
+            "requires": {
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "backo2": {
@@ -591,6 +710,18 @@
             "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
             "dev": true
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
         "bufferstreams": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.0.1.tgz",
@@ -824,6 +955,28 @@
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
+        "collection-map": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+            "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+            "dev": true,
+            "requires": {
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -894,6 +1047,18 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
         "connect": {
             "version": "3.6.6",
             "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -929,6 +1094,15 @@
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -940,6 +1114,16 @@
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
+        },
+        "copy-props": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+            "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+            "dev": true,
+            "requires": {
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -978,6 +1162,16 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1014,13 +1208,36 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
-        "defaults": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+        "default-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+            "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "clone": "^1.0.2"
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "default-resolution": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+            "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -1082,12 +1299,6 @@
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
         },
-        "deprecated": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-            "dev": true
-        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1141,6 +1352,28 @@
                 }
             }
         },
+        "duplexify": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "each-props": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+            "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
+            }
+        },
         "easy-extender": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
@@ -1188,12 +1421,23 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-            "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
             "requires": {
-                "once": "~1.3.0"
+                "once": "^1.4.0"
+            },
+            "dependencies": {
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                }
             }
         },
         "engine.io": {
@@ -1262,6 +1506,50 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -1396,6 +1684,23 @@
             "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -1575,12 +1880,6 @@
                 }
             }
         },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-            "dev": true
-        },
         "find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -1592,26 +1891,17 @@
             }
         },
         "findup-sync": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+            "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
             "dev": true,
             "requires": {
                 "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
+                "is-glob": "^4.0.0",
                 "micromatch": "^3.0.4",
                 "resolve-dir": "^1.0.1"
             },
             "dependencies": {
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -1636,9 +1926,9 @@
             }
         },
         "fined": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
-            "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+            "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
             "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.2",
@@ -1648,17 +1938,21 @@
                 "parse-filepath": "^1.0.1"
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
         "flagged-respawn": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
             "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
             "dev": true
+        },
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
+            }
         },
         "follow-redirects": {
             "version": "1.7.0",
@@ -1742,6 +2036,16 @@
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^3.0.0",
                 "universalify": "^0.1.0"
+            }
+        },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs.realpath": {
@@ -2310,6 +2614,12 @@
                 "rimraf": "2"
             }
         },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
         "gauge": {
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -2332,15 +2642,6 @@
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true
                 }
-            }
-        },
-        "gaze": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-            "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-            "dev": true,
-            "requires": {
-                "globule": "~0.1.0"
             }
         },
         "get-caller-file": {
@@ -2371,26 +2672,17 @@
             }
         },
         "glob": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-            "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "dev": true,
             "requires": {
+                "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
-            },
-            "dependencies": {
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                }
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2451,80 +2743,35 @@
             }
         },
         "glob-stream": {
-            "version": "3.1.18",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+            "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
             "dev": true,
             "requires": {
-                "gaze": "^0.5.1"
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "dev": true,
-            "requires": {
-                "find-index": "^0.1.1"
+                "anymatch": "^2.0.0",
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "is-negated-glob": "^1.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
@@ -2551,58 +2798,6 @@
                 "which": "^1.2.14"
             }
         },
-        "globule": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-            "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-            "dev": true,
-            "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "3.1.21",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-                    "dev": true
-                },
-                "inherits": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                    "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "0.2.14",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
-                    }
-                }
-            }
-        },
         "glogg": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -2625,31 +2820,72 @@
             "dev": true
         },
         "gulp": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-            "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+            "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
+                "glob-watcher": "^5.0.3",
+                "gulp-cli": "^2.2.0",
+                "undertaker": "^1.2.1",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-                    "dev": true
+                "gulp-cli": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+                    "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^3.1.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
                 }
             }
         },
@@ -2987,6 +3223,12 @@
                 "sparkles": "^1.0.0"
             }
         },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
+        },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3026,9 +3268,9 @@
             }
         },
         "homedir-polyfill": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-            "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
             "dev": true,
             "requires": {
                 "parse-passwd": "^1.0.0"
@@ -3296,6 +3538,12 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+            "dev": true
+        },
         "is-number": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3376,6 +3624,12 @@
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
+        "is-valid-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+            "dev": true
+        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3436,6 +3690,12 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3463,11 +3723,36 @@
                 "verror": "1.10.0"
             }
         },
+        "just-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+            "dev": true
+        },
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
             "dev": true
+        },
+        "last-run": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+            "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+            "dev": true,
+            "requires": {
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.5"
+            }
         },
         "lcid": {
             "version": "1.0.0",
@@ -3478,14 +3763,23 @@
                 "invert-kv": "^1.0.0"
             }
         },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "dev": true,
+            "requires": {
+                "flush-write-stream": "^1.0.2"
+            }
+        },
         "liftoff": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+            "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
             "dev": true,
             "requires": {
                 "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
+                "findup-sync": "^3.0.0",
                 "fined": "^1.0.1",
                 "flagged-respawn": "^1.0.0",
                 "is-plain-object": "^2.0.4",
@@ -3710,12 +4004,6 @@
                 "signal-exit": "^3.0.0"
             }
         },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-            "dev": true
-        },
         "make-iterator": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -3744,6 +4032,62 @@
             "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
+            }
+        },
+        "matchdep": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+            "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+            "dev": true,
+            "requires": {
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
+                "stack-trace": "0.0.10"
+            },
+            "dependencies": {
+                "findup-sync": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+                    "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "dev": true,
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^3.1.0",
+                        "micromatch": "^3.0.4",
+                        "resolve-dir": "^1.0.1"
+                    }
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                }
             }
         },
         "math-random": {
@@ -3964,6 +4308,12 @@
                 "duplexer2": "0.0.2"
             }
         },
+        "mute-stdout": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+            "dev": true
+        },
         "nan": {
             "version": "2.12.1",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
@@ -3990,16 +4340,16 @@
                 "to-regex": "^3.0.1"
             }
         },
-        "natives": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-            "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-            "dev": true
-        },
         "negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
         "node-gyp": {
@@ -4156,6 +4506,15 @@
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
         },
+        "now-and-later": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+            "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.2"
+            }
+        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -4229,6 +4588,12 @@
                 }
             }
         },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
         "object-path": {
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
@@ -4242,6 +4607,18 @@
             "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -4307,6 +4684,27 @@
                 "isobject": "^3.0.1"
             }
         },
+        "object.reduce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+            "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "on-finished": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4340,22 +4738,14 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "orchestrator": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+        "ordered-read-streams": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
+                "readable-stream": "^2.0.1"
             }
-        },
-        "ordered-read-streams": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-            "dev": true
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -4722,6 +5112,27 @@
             "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
         },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
+        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -4887,6 +5298,27 @@
                 "safe-regex": "^1.1.0"
             }
         },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "dev": true,
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4919,6 +5351,17 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
             "dev": true
+        },
+        "replace-homedir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+            "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
+            }
         },
         "request": {
             "version": "2.88.0",
@@ -4991,6 +5434,15 @@
             "requires": {
                 "expand-tilde": "^2.0.0",
                 "global-modules": "^1.0.0"
+            }
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
+            "requires": {
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -5172,6 +5624,15 @@
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
             "dev": true
         },
+        "semver-greatest-satisfied-range": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+            "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+            "dev": true,
+            "requires": {
+                "sver-compat": "^1.5.0"
+            }
+        },
         "send": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -5227,12 +5688,6 @@
                     "dev": true
                 }
             }
-        },
-        "sequencify": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-            "dev": true
         },
         "serve-index": {
             "version": "1.9.1",
@@ -5335,12 +5790,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-            "dev": true
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
             "dev": true
         },
         "signal-exit": {
@@ -5678,6 +6127,12 @@
                 "tweetnacl": "~0.14.0"
             }
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -5714,10 +6169,16 @@
                 "readable-stream": "^2.0.1"
             }
         },
-        "stream-consume": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-            "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
+        "stream-exhaust": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+            "dev": true
+        },
+        "stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
         "stream-throttle": {
@@ -5804,6 +6265,16 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "sver-compat": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+            "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "symbol-observable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -5841,13 +6312,14 @@
                 "xtend": "~4.0.1"
             }
         },
-        "tildify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+        "through2-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -5855,6 +6327,16 @@
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
             "dev": true
+        },
+        "to-absolute-glob": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+            "dev": true,
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
+            }
         },
         "to-array": {
             "version": "0.1.4",
@@ -5902,6 +6384,15 @@
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
+            }
+        },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.3"
             }
         },
         "toidentifier": {
@@ -5974,6 +6465,18 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
         "ua-parser-js": {
             "version": "0.7.17",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -5990,6 +6493,29 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
+        },
+        "undertaker": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+            "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
+            }
+        },
+        "undertaker-registry": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
             "dev": true
         },
         "union-value": {
@@ -6028,10 +6554,14 @@
             }
         },
         "unique-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-            "dev": true
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
+            }
         },
         "universalify": {
             "version": "0.1.2",
@@ -6118,12 +6648,6 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
-        "user-home": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-            "dev": true
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6143,12 +6667,12 @@
             "dev": true
         },
         "v8flags": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+            "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
             "dev": true,
             "requires": {
-                "user-home": "^1.1.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -6160,6 +6684,12 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -6220,88 +6750,109 @@
             }
         },
         "vinyl-fs": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
                     "dev": true
                 },
-                "graceful-fs": {
-                    "version": "3.0.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-                    "dev": true,
-                    "requires": {
-                        "natives": "^1.1.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "strip-bom": {
+                "clone-stats": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-                    "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-                    "dev": true,
-                    "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "is-utf8": "^0.2.0"
-                    }
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
                 },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
                 },
                 "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }

--- a/lesson02/assignment/package.json
+++ b/lesson02/assignment/package.json
@@ -10,7 +10,7 @@
     "license": "ISC",
     "devDependencies": {
         "browser-sync": "^2.26.5",
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.2",
         "gulp-autoprefixer": "^6.1.0",
         "gulp-minify-css": "^1.2.4",
         "gulp-plumber": "^1.2.0",

--- a/lesson03/activity/gulpfile.js
+++ b/lesson03/activity/gulpfile.js
@@ -1,14 +1,12 @@
-var gulp = require('gulp'),
+const {dest, series, src, watch} = require('gulp'),
     sass = require('gulp-sass'),
     autoprefix = require('gulp-autoprefixer'),
-    watch = require('gulp-watch'),
     plumber = require('gulp-plumber'),
     gutil = require('gulp-util'),
-    minifycss = require('gulp-minify-css'),
-    browserSync = require('browser-sync').create();
+    browserSync = require('browser-sync').create()
 
-gulp.task('sass', function() {
-    gulp.src('css/*.scss')
+function compileSass() {
+    return src('css/*.scss')
         .pipe(plumber())
         .pipe(sass())
         .pipe(
@@ -16,23 +14,19 @@ gulp.task('sass', function() {
                 browsers: ['> .5%'],
             })
         )
-        .pipe(minifycss({ compatibility: 'ie8' }))
-        .pipe(gulp.dest('css/'))
+        .pipe(dest('css/'))
         .pipe(browserSync.stream());
-});
+}
 
-gulp.task('watch', function() {
-    gulp.watch('css/*.scss', ['sass']);
-    gulp.watch('*.html').on('change', browserSync.reload);
-});
-
-gulp.task('browser-sync', function() {
+function browserSyncs() {
     browserSync.init({
         notify: false,
         server: {
             baseDir: './',
         },
-    });
-});
+    })
+    watch(['css/*.scss']).on('change', compileSass)
+    watch(['*.html']).on('change', browserSync.reload)
+}
 
-gulp.task('default', ['watch', 'browser-sync']);
+exports.default = browserSyncs

--- a/lesson03/activity/package-lock.json
+++ b/lesson03/activity/package-lock.json
@@ -48,7 +48,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-            "dev": true,
             "requires": {
                 "ansi-wrap": "^0.1.0"
             }
@@ -66,7 +65,6 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-            "dev": true,
             "requires": {
                 "ansi-wrap": "0.1.0"
             }
@@ -83,8 +81,7 @@
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "dev": true
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
             "version": "2.2.1",
@@ -95,14 +92,12 @@
         "ansi-wrap": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-            "dev": true
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
         },
         "anymatch": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-            "dev": true,
             "requires": {
                 "micromatch": "^3.1.4",
                 "normalize-path": "^2.1.1"
@@ -112,7 +107,6 @@
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "dev": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -133,11 +127,18 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-                    "dev": true,
                     "requires": {
                         "remove-trailing-separator": "^1.0.1"
                     }
                 }
+            }
+        },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "requires": {
+                "buffer-equal": "^1.0.0"
             }
         },
         "aproba": {
@@ -149,8 +150,7 @@
         "archy": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-            "dev": true
+            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "are-we-there-yet": {
             "version": "1.1.5",
@@ -165,20 +165,33 @@
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-            "dev": true
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "arr-filter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+            "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
         },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-            "dev": true
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+            "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
         },
         "arr-union": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-            "dev": true
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
         },
         "array-differ": {
             "version": "1.0.0",
@@ -189,8 +202,7 @@
         "array-each": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-            "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
-            "dev": true
+            "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
         },
         "array-find-index": {
             "version": "1.0.2",
@@ -198,11 +210,58 @@
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
+        "array-initial": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+            "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+            "requires": {
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                }
+            }
+        },
+        "array-last": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+            "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+            "requires": {
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                }
+            }
+        },
         "array-slice": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
-            "dev": true
+            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+        },
+        "array-sort": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+            "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+            "requires": {
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -213,8 +272,7 @@
         "array-unique": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-            "dev": true
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "arraybuffer.slice": {
             "version": "0.0.7",
@@ -240,8 +298,7 @@
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-            "dev": true
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
         },
         "async": {
             "version": "1.5.2",
@@ -249,11 +306,21 @@
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
+        "async-done": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+            "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^2.0.0",
+                "stream-exhaust": "^1.0.1"
+            }
+        },
         "async-each": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
-            "integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==",
-            "dev": true
+            "integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg=="
         },
         "async-each-series": {
             "version": "0.1.1",
@@ -273,6 +340,14 @@
             "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
         },
+        "async-settle": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+            "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+            "requires": {
+                "async-done": "^1.2.2"
+            }
+        },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -282,8 +357,7 @@
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "dev": true
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
         "autoprefixer": {
             "version": "9.5.1",
@@ -321,6 +395,22 @@
                 "is-buffer": "^1.1.5"
             }
         },
+        "bach": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+            "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+            "requires": {
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
+            }
+        },
         "backo2": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -330,14 +420,12 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-            "dev": true,
             "requires": {
                 "cache-base": "^1.0.1",
                 "class-utils": "^0.3.5",
@@ -352,7 +440,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -361,7 +448,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -370,7 +456,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -379,7 +464,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -433,8 +517,7 @@
         "binary-extensions": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-            "dev": true
+            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
         },
         "blob": {
             "version": "0.0.5",
@@ -455,7 +538,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -465,7 +547,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-            "dev": true,
             "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -483,7 +564,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -600,6 +680,16 @@
             "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
             "dev": true
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
         "bufferstreams": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.0.1.tgz",
@@ -645,7 +735,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-            "dev": true,
             "requires": {
                 "collection-visit": "^1.0.0",
                 "component-emitter": "^1.2.1",
@@ -667,8 +756,7 @@
         "camelcase": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-            "dev": true
+            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         },
         "camelcase-keys": {
             "version": "2.1.0",
@@ -717,7 +805,6 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
             "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
-            "dev": true,
             "requires": {
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
@@ -737,7 +824,6 @@
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "define-property": "^0.2.5",
@@ -749,7 +835,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -790,7 +875,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1",
@@ -806,8 +890,7 @@
         "clone-buffer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-            "dev": true
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
         },
         "clone-stats": {
             "version": "0.0.1",
@@ -819,7 +902,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "process-nextick-args": "^2.0.0",
@@ -829,14 +911,32 @@
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "dev": true
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "collection-map": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+            "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+            "requires": {
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
         },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-            "dev": true,
             "requires": {
                 "map-visit": "^1.0.0",
                 "object-visit": "^1.0.0"
@@ -860,8 +960,7 @@
         "color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "dev": true
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
         },
         "combined-stream": {
             "version": "1.0.7",
@@ -887,8 +986,7 @@
         "component-emitter": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-            "dev": true
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "component-inherit": {
             "version": "0.0.3",
@@ -899,8 +997,18 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
         },
         "connect": {
             "version": "3.6.6",
@@ -937,6 +1045,14 @@
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -946,14 +1062,21 @@
         "copy-descriptor": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-            "dev": true
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "copy-props": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+            "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+            "requires": {
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cross-spawn": {
             "version": "3.0.1",
@@ -986,6 +1109,15 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1013,29 +1145,45 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-            "dev": true
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-            "dev": true
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
-        "defaults": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-            "dev": true,
+        "default-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+            "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "requires": {
-                "clone": "^1.0.2"
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+            }
+        },
+        "default-resolution": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ="
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "requires": {
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-            "dev": true,
             "requires": {
                 "is-descriptor": "^1.0.2",
                 "isobject": "^3.0.1"
@@ -1045,7 +1193,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1054,7 +1201,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1063,7 +1209,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -1090,12 +1235,6 @@
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
         },
-        "deprecated": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-            "dev": true
-        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1105,8 +1244,7 @@
         "detect-file": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-            "dev": true
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
         },
         "dev-ip": {
             "version": "1.0.1",
@@ -1147,6 +1285,26 @@
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                     "dev": true
                 }
+            }
+        },
+        "duplexify": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "requires": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "each-props": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+            "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+            "requires": {
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
             }
         },
         "easy-extender": {
@@ -1196,12 +1354,21 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-            "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
-            "dev": true,
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "requires": {
-                "once": "~1.3.0"
+                "once": "^1.4.0"
+            },
+            "dependencies": {
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                }
             }
         },
         "engine.io": {
@@ -1267,9 +1434,48 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -1300,7 +1506,6 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-            "dev": true,
             "requires": {
                 "debug": "^2.3.3",
                 "define-property": "^0.2.5",
@@ -1315,7 +1520,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -1324,7 +1528,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -1333,7 +1536,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -1401,22 +1603,34 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-            "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+                }
             }
         },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "dev": true
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extend-shallow": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-            "dev": true,
             "requires": {
                 "assign-symbols": "^1.0.0",
                 "is-extendable": "^1.0.1"
@@ -1426,7 +1640,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -1437,7 +1650,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-            "dev": true,
             "requires": {
                 "array-unique": "^0.3.2",
                 "define-property": "^1.0.0",
@@ -1453,7 +1665,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -1462,7 +1673,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -1471,7 +1681,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1480,7 +1689,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1489,7 +1697,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -1508,7 +1715,6 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
             "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
-            "dev": true,
             "requires": {
                 "ansi-gray": "^0.1.1",
                 "color-support": "^1.1.3",
@@ -1538,7 +1744,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-number": "^3.0.0",
@@ -1550,7 +1755,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -1583,48 +1787,30 @@
                 }
             }
         },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-            "dev": true
-        },
         "find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-            "dev": true,
             "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
-            "dev": true,
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+            "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
             "requires": {
                 "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
+                "is-glob": "^4.0.0",
                 "micromatch": "^3.0.4",
                 "resolve-dir": "^1.0.1"
             },
             "dependencies": {
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "dev": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -1644,10 +1830,9 @@
             }
         },
         "fined": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
-            "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
-            "dev": true,
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+            "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
             "requires": {
                 "expand-tilde": "^2.0.2",
                 "is-plain-object": "^2.0.3",
@@ -1656,17 +1841,19 @@
                 "parse-filepath": "^1.0.1"
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
         "flagged-respawn": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
-            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
-            "dev": true
+            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
+        },
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
+            }
         },
         "follow-redirects": {
             "version": "1.7.0",
@@ -1697,8 +1884,7 @@
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "for-own": {
             "version": "0.1.5",
@@ -1730,7 +1916,6 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-            "dev": true,
             "requires": {
                 "map-cache": "^0.2.2"
             }
@@ -1752,17 +1937,24 @@
                 "universalify": "^0.1.0"
             }
         },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
             "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "nan": "^2.9.2",
@@ -1772,25 +1964,21 @@
                 "abbrev": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "delegates": "^1.0.0",
@@ -1800,13 +1988,11 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
@@ -1816,37 +2002,31 @@
                 "chownr": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "debug": {
                     "version": "2.6.9",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ms": "2.0.0"
@@ -1855,25 +2035,21 @@
                 "deep-extend": {
                     "version": "0.6.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -1882,13 +2058,11 @@
                 "fs.realpath": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "aproba": "^1.0.3",
@@ -1904,7 +2078,6 @@
                 "glob": {
                     "version": "7.1.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -1918,13 +2091,11 @@
                 "has-unicode": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.24",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
@@ -1933,7 +2104,6 @@
                 "ignore-walk": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minimatch": "^3.0.4"
@@ -1942,7 +2112,6 @@
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "once": "^1.3.0",
@@ -1952,19 +2121,16 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
@@ -1973,13 +2139,11 @@
                 "isarray": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
@@ -1988,13 +2152,11 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
@@ -2004,7 +2166,6 @@
                 "minizlib": {
                     "version": "1.2.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -2013,7 +2174,6 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
@@ -2022,13 +2182,11 @@
                 "ms": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "needle": {
                     "version": "2.2.4",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "debug": "^2.1.2",
@@ -2039,7 +2197,6 @@
                 "node-pre-gyp": {
                     "version": "0.10.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
@@ -2057,7 +2214,6 @@
                 "nopt": {
                     "version": "4.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "abbrev": "1",
@@ -2067,13 +2223,11 @@
                 "npm-bundled": {
                     "version": "1.0.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.2.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ignore-walk": "^3.0.1",
@@ -2083,7 +2237,6 @@
                 "npmlog": {
                     "version": "4.1.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "are-we-there-yet": "~1.1.2",
@@ -2095,19 +2248,16 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "wrappy": "1"
@@ -2116,19 +2266,16 @@
                 "os-homedir": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "os-homedir": "^1.0.0",
@@ -2138,19 +2285,16 @@
                 "path-is-absolute": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.8",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "deep-extend": "^0.6.0",
@@ -2162,7 +2306,6 @@
                         "minimist": {
                             "version": "1.2.0",
                             "bundled": true,
-                            "dev": true,
                             "optional": true
                         }
                     }
@@ -2170,7 +2313,6 @@
                 "readable-stream": {
                     "version": "2.3.6",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -2185,7 +2327,6 @@
                 "rimraf": {
                     "version": "2.6.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "glob": "^7.1.3"
@@ -2194,43 +2335,36 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "semver": {
                     "version": "5.6.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
@@ -2241,7 +2375,6 @@
                 "string_decoder": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
@@ -2250,7 +2383,6 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
@@ -2259,13 +2391,11 @@
                 "strip-json-comments": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "4.4.8",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "chownr": "^1.1.1",
@@ -2280,13 +2410,11 @@
                 "util-deprecate": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "string-width": "^1.0.2 || 2"
@@ -2295,13 +2423,11 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -2317,6 +2443,11 @@
                 "mkdirp": ">=0.5 0",
                 "rimraf": "2"
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "gauge": {
             "version": "2.7.4",
@@ -2342,20 +2473,10 @@
                 }
             }
         },
-        "gaze": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-            "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-            "dev": true,
-            "requires": {
-                "globule": "~0.1.0"
-            }
-        },
         "get-caller-file": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-            "dev": true
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
         },
         "get-stdin": {
             "version": "4.0.1",
@@ -2366,8 +2487,7 @@
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-            "dev": true
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
         },
         "getpass": {
             "version": "0.1.7",
@@ -2379,26 +2499,16 @@
             }
         },
         "glob": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-            "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-            "dev": true,
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "requires": {
+                "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
-            },
-            "dependencies": {
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                }
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2441,7 +2551,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-            "dev": true,
             "requires": {
                 "is-glob": "^3.1.0",
                 "path-dirname": "^1.0.0"
@@ -2451,7 +2560,6 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.0"
                     }
@@ -2459,87 +2567,39 @@
             }
         },
         "glob-stream": {
-            "version": "3.1.18",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-            "dev": true,
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-            "dev": true,
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+            "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
             "requires": {
-                "gaze": "^0.5.1"
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "dev": true,
-            "requires": {
-                "find-index": "^0.1.1"
+                "anymatch": "^2.0.0",
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "is-negated-glob": "^1.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-            "dev": true,
             "requires": {
                 "global-prefix": "^1.0.1",
                 "is-windows": "^1.0.1",
@@ -2550,7 +2610,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-            "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.2",
                 "homedir-polyfill": "^1.0.1",
@@ -2559,63 +2618,10 @@
                 "which": "^1.2.14"
             }
         },
-        "globule": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-            "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-            "dev": true,
-            "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "3.1.21",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-                    "dev": true
-                },
-                "inherits": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                    "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "0.2.14",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
-                    }
-                }
-            }
-        },
         "glogg": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
             "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
-            "dev": true,
             "requires": {
                 "sparkles": "^1.0.0"
             }
@@ -2623,8 +2629,7 @@
         "graceful-fs": {
             "version": "4.1.15",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-            "dev": true
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
         },
         "graceful-readlink": {
             "version": "1.0.1",
@@ -2633,31 +2638,68 @@
             "dev": true
         },
         "gulp": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-            "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
-            "dev": true,
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+            "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
+                "glob-watcher": "^5.0.3",
+                "gulp-cli": "^2.2.0",
+                "undertaker": "^1.2.1",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-                    "dev": true
+                "gulp-cli": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+                    "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+                    "requires": {
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^3.1.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
                 }
             }
         },
@@ -2944,7 +2986,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true,
             "requires": {
                 "glogg": "^1.0.0"
             }
@@ -3004,6 +3045,11 @@
                 "sparkles": "^1.0.0"
             }
         },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+        },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3014,7 +3060,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-            "dev": true,
             "requires": {
                 "get-value": "^2.0.6",
                 "has-values": "^1.0.0",
@@ -3025,7 +3070,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "kind-of": "^4.0.0"
@@ -3035,7 +3079,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3046,7 +3089,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
             "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-            "dev": true,
             "requires": {
                 "parse-passwd": "^1.0.0"
             }
@@ -3054,8 +3096,7 @@
         "hosted-git-info": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-            "dev": true
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
         },
         "http-errors": {
             "version": "1.7.2",
@@ -3139,7 +3180,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -3148,32 +3188,27 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-            "dev": true
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "interpret": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-            "dev": true
+            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
         },
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-            "dev": true
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
         },
         "is-absolute": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-            "dev": true,
             "requires": {
                 "is-relative": "^1.0.0",
                 "is-windows": "^1.0.1"
@@ -3183,7 +3218,6 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -3192,7 +3226,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3202,14 +3235,12 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "is-binary-path": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-            "dev": true,
             "requires": {
                 "binary-extensions": "^1.0.0"
             }
@@ -3217,14 +3248,12 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-data-descriptor": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -3233,7 +3262,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3244,7 +3272,6 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-            "dev": true,
             "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -3254,8 +3281,7 @@
                 "kind-of": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
                 }
             }
         },
@@ -3277,14 +3303,12 @@
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
         },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-finite": {
             "version": "1.0.2",
@@ -3299,7 +3323,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "dev": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -3308,16 +3331,19 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
+        },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
         },
         "is-number": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -3326,7 +3352,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3346,7 +3371,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -3367,7 +3391,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-            "dev": true,
             "requires": {
                 "is-unc-path": "^1.0.0"
             }
@@ -3382,7 +3405,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-            "dev": true,
             "requires": {
                 "unc-path-regex": "^0.1.2"
             }
@@ -3390,14 +3412,17 @@
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-            "dev": true
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+        },
+        "is-valid-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
         },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-            "dev": true
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         },
         "is-wsl": {
             "version": "1.1.0",
@@ -3414,14 +3439,12 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-            "dev": true
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "isstream": {
             "version": "0.1.2",
@@ -3453,6 +3476,11 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3480,29 +3508,56 @@
                 "verror": "1.10.0"
             }
         },
+        "just-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
+        },
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-            "dev": true
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        },
+        "last-run": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+            "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+            "requires": {
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "requires": {
+                "readable-stream": "^2.0.5"
+            }
         },
         "lcid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-            "dev": true,
             "requires": {
                 "invert-kv": "^1.0.0"
             }
         },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "requires": {
+                "flush-write-stream": "^1.0.2"
+            }
+        },
         "liftoff": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
-            "dev": true,
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+            "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
             "requires": {
                 "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
+                "findup-sync": "^3.0.0",
                 "fined": "^1.0.1",
                 "flagged-respawn": "^1.0.0",
                 "is-plain-object": "^2.0.4",
@@ -3521,7 +3576,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -3721,17 +3775,10 @@
                 "signal-exit": "^3.0.0"
             }
         },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-            "dev": true
-        },
         "make-iterator": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
             "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
-            "dev": true,
             "requires": {
                 "kind-of": "^6.0.2"
             }
@@ -3739,8 +3786,7 @@
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-            "dev": true
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
         },
         "map-obj": {
             "version": "1.0.1",
@@ -3752,9 +3798,60 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-            "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
+            }
+        },
+        "matchdep": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+            "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+            "requires": {
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
+                "stack-trace": "0.0.10"
+            },
+            "dependencies": {
+                "findup-sync": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+                    "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^3.1.0",
+                        "micromatch": "^3.0.4",
+                        "resolve-dir": "^1.0.1"
+                    }
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                }
             }
         },
         "math-random": {
@@ -3914,7 +4011,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -3935,7 +4031,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
             "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-            "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
                 "is-extendable": "^1.0.1"
@@ -3945,7 +4040,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -3972,8 +4066,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "multipipe": {
             "version": "0.1.2",
@@ -3984,17 +4077,20 @@
                 "duplexer2": "0.0.2"
             }
         },
+        "mute-stdout": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg=="
+        },
         "nan": {
             "version": "2.13.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-            "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
-            "dev": true
+            "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
         },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -4009,17 +4105,16 @@
                 "to-regex": "^3.0.1"
             }
         },
-        "natives": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-            "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-            "dev": true
-        },
         "negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
             "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node-gyp": {
             "version": "3.8.0",
@@ -4146,7 +4241,6 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "resolve": "^1.10.0",
@@ -4157,14 +4251,21 @@
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "normalize-range": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
+        },
+        "now-and-later": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+            "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+            "requires": {
+                "once": "^1.3.2"
+            }
         },
         "npmlog": {
             "version": "4.1.2",
@@ -4187,8 +4288,7 @@
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "oauth-sign": {
             "version": "0.9.0",
@@ -4212,7 +4312,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-            "dev": true,
             "requires": {
                 "copy-descriptor": "^0.1.0",
                 "define-property": "^0.2.5",
@@ -4223,7 +4322,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -4232,12 +4330,16 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
                 }
             }
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "object-path": {
             "version": "0.9.2",
@@ -4249,16 +4351,25 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
-            "dev": true,
             "requires": {
                 "array-each": "^1.0.1",
                 "array-slice": "^1.0.0",
@@ -4270,7 +4381,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-                    "dev": true,
                     "requires": {
                         "for-in": "^1.0.1"
                     }
@@ -4281,7 +4391,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
-            "dev": true,
             "requires": {
                 "for-own": "^1.0.0",
                 "make-iterator": "^1.0.0"
@@ -4291,7 +4400,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-                    "dev": true,
                     "requires": {
                         "for-in": "^1.0.1"
                     }
@@ -4312,9 +4420,27 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
+            }
+        },
+        "object.reduce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+            "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
             }
         },
         "on-finished": {
@@ -4330,7 +4456,6 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
             "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -4350,22 +4475,13 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "orchestrator": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
-            }
-        },
         "ordered-read-streams": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-            "dev": true
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+            "requires": {
+                "readable-stream": "^2.0.1"
+            }
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -4377,7 +4493,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-            "dev": true,
             "requires": {
                 "lcid": "^1.0.0"
             }
@@ -4402,7 +4517,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
-            "dev": true,
             "requires": {
                 "is-absolute": "^1.0.0",
                 "map-cache": "^0.2.0",
@@ -4442,7 +4556,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "dev": true,
             "requires": {
                 "error-ex": "^1.2.0"
             }
@@ -4450,14 +4563,12 @@
         "parse-node-version": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-            "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-            "dev": true
+            "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
         },
         "parse-passwd": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-            "dev": true
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
         },
         "parseqs": {
             "version": "0.0.5",
@@ -4486,20 +4597,17 @@
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-            "dev": true
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
         },
         "path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-            "dev": true
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
         "path-exists": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "dev": true,
             "requires": {
                 "pinkie-promise": "^2.0.0"
             }
@@ -4507,20 +4615,17 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-parse": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-            "dev": true
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "path-root": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-            "dev": true,
             "requires": {
                 "path-root-regex": "^0.1.0"
             }
@@ -4528,14 +4633,12 @@
         "path-root-regex": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
-            "dev": true
+            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
         },
         "path-type": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "pify": "^2.0.0",
@@ -4551,20 +4654,17 @@
         "pify": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
             "requires": {
                 "pinkie": "^2.0.0"
             }
@@ -4634,8 +4734,7 @@
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-            "dev": true
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "postcss": {
             "version": "7.0.16",
@@ -4711,14 +4810,12 @@
         "pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-            "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-            "dev": true
+            "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
         },
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-            "dev": true
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "pseudomap": {
             "version": "1.0.2",
@@ -4731,6 +4828,25 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
             "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
+        },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
         },
         "punycode": {
             "version": "2.1.1",
@@ -4785,7 +4901,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-            "dev": true,
             "requires": {
                 "load-json-file": "^1.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -4796,7 +4911,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-            "dev": true,
             "requires": {
                 "find-up": "^1.0.0",
                 "read-pkg": "^1.0.0"
@@ -4806,7 +4920,6 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -4820,8 +4933,7 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 }
             }
         },
@@ -4829,7 +4941,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
             "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11",
                 "micromatch": "^3.1.10",
@@ -4840,7 +4951,6 @@
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "dev": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -4863,7 +4973,6 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dev": true,
             "requires": {
                 "resolve": "^1.1.6"
             }
@@ -4891,29 +5000,44 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
             }
         },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-            "dev": true
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
         },
         "repeat-element": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-            "dev": true
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
         },
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "repeating": {
             "version": "2.0.1",
@@ -4929,6 +5053,16 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
             "dev": true
+        },
+        "replace-homedir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+            "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+            "requires": {
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
+            }
         },
         "request": {
             "version": "2.88.0",
@@ -4969,14 +5103,12 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-            "dev": true
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
         "require-main-filename": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-            "dev": true
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
         "requires-port": {
             "version": "1.0.0",
@@ -4988,7 +5120,6 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
             "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
-            "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
             }
@@ -4997,17 +5128,23 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-            "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.0",
                 "global-modules": "^1.0.0"
             }
         },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "requires": {
+                "value-or-function": "^3.0.0"
+            }
+        },
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-            "dev": true
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "resp-modifier": {
             "version": "6.0.2",
@@ -5033,8 +5170,7 @@
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-            "dev": true
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
         },
         "rimraf": {
             "version": "2.6.3",
@@ -5079,14 +5215,12 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safe-regex": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-            "dev": true,
             "requires": {
                 "ret": "~0.1.10"
             }
@@ -5179,8 +5313,15 @@
         "semver": {
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-            "dev": true
+            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        },
+        "semver-greatest-satisfied-range": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+            "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+            "requires": {
+                "sver-compat": "^1.5.0"
+            }
         },
         "send": {
             "version": "0.16.2",
@@ -5237,12 +5378,6 @@
                     "dev": true
                 }
             }
-        },
-        "sequencify": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-            "dev": true
         },
         "serve-index": {
             "version": "1.9.1",
@@ -5315,14 +5450,12 @@
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-            "dev": true
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "set-value": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-extendable": "^0.1.1",
@@ -5334,7 +5467,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -5345,12 +5477,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-            "dev": true
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
             "dev": true
         },
         "signal-exit": {
@@ -5369,7 +5495,6 @@
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-            "dev": true,
             "requires": {
                 "base": "^0.11.1",
                 "debug": "^2.2.0",
@@ -5385,7 +5510,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -5394,7 +5518,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -5403,7 +5526,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -5414,7 +5536,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-            "dev": true,
             "requires": {
                 "define-property": "^1.0.0",
                 "isobject": "^3.0.0",
@@ -5425,7 +5546,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -5434,7 +5554,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5443,7 +5562,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5452,7 +5570,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -5465,7 +5582,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.2.0"
             },
@@ -5474,7 +5590,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -5602,14 +5717,12 @@
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-resolve": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-            "dev": true,
             "requires": {
                 "atob": "^2.1.1",
                 "decode-uri-component": "^0.2.0",
@@ -5621,20 +5734,17 @@
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-            "dev": true
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
         "sparkles": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
-            "dev": true
+            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
         },
         "spdx-correct": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
             "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-            "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -5643,14 +5753,12 @@
         "spdx-exceptions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-            "dev": true
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-            "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -5659,14 +5767,12 @@
         "spdx-license-ids": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
-            "dev": true
+            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
         },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
             }
@@ -5688,11 +5794,15 @@
                 "tweetnacl": "~0.14.0"
             }
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-            "dev": true,
             "requires": {
                 "define-property": "^0.2.5",
                 "object-copy": "^0.1.0"
@@ -5702,7 +5812,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -5724,11 +5833,15 @@
                 "readable-stream": "^2.0.1"
             }
         },
-        "stream-consume": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-            "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
-            "dev": true
+        "stream-exhaust": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw=="
+        },
+        "stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
         },
         "stream-throttle": {
             "version": "0.1.3",
@@ -5744,7 +5857,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "dev": true,
             "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5755,7 +5867,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -5764,7 +5875,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -5773,7 +5883,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
             "requires": {
                 "is-utf8": "^0.2.0"
             }
@@ -5814,6 +5923,15 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "sver-compat": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+            "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+            "requires": {
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "symbol-observable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -5845,26 +5963,33 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-            "dev": true,
             "requires": {
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
             }
         },
-        "tildify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-            "dev": true,
+        "through2-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "requires": {
-                "os-homedir": "^1.0.0"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-            "dev": true
+            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+        },
+        "to-absolute-glob": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
+            }
         },
         "to-array": {
             "version": "0.1.4",
@@ -5876,7 +6001,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -5885,7 +6009,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -5896,7 +6019,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-            "dev": true,
             "requires": {
                 "define-property": "^2.0.2",
                 "extend-shallow": "^3.0.2",
@@ -5908,10 +6030,17 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
+            }
+        },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "requires": {
+                "through2": "^2.0.3"
             }
         },
         "toidentifier": {
@@ -5984,6 +6113,16 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+        },
         "ua-parser-js": {
             "version": "0.7.17",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -5999,14 +6138,33 @@
         "unc-path-regex": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-            "dev": true
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+        },
+        "undertaker": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+            "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+            "requires": {
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
+            }
+        },
+        "undertaker-registry": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA="
         },
         "union-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
@@ -6018,7 +6176,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -6027,7 +6184,6 @@
                     "version": "0.4.3",
                     "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-extendable": "^0.1.1",
@@ -6038,10 +6194,13 @@
             }
         },
         "unique-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-            "dev": true
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+            "requires": {
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
+            }
         },
         "universalify": {
             "version": "0.1.2",
@@ -6059,7 +6218,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-            "dev": true,
             "requires": {
                 "has-value": "^0.3.1",
                 "isobject": "^3.0.0"
@@ -6069,7 +6227,6 @@
                     "version": "0.3.1",
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-                    "dev": true,
                     "requires": {
                         "get-value": "^2.0.3",
                         "has-values": "^0.1.4",
@@ -6080,7 +6237,6 @@
                             "version": "2.1.0",
                             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                            "dev": true,
                             "requires": {
                                 "isarray": "1.0.0"
                             }
@@ -6090,22 +6246,19 @@
                 "has-values": {
                     "version": "0.1.4",
                     "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-                    "dev": true
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
                 },
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 }
             }
         },
         "upath": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
-            "dev": true
+            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q=="
         },
         "uri-js": {
             "version": "4.2.2",
@@ -6119,26 +6272,17 @@
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-            "dev": true
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
         "use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-            "dev": true
-        },
-        "user-home": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-            "dev": true
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
         },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "utils-merge": {
             "version": "1.0.1",
@@ -6153,23 +6297,26 @@
             "dev": true
         },
         "v8flags": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-            "dev": true,
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+            "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
             "requires": {
-                "user-home": "^1.1.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM="
         },
         "verror": {
             "version": "1.10.0",
@@ -6230,88 +6377,107 @@
             }
         },
         "vinyl-fs": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
-            "dev": true,
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
                 },
-                "graceful-fs": {
-                    "version": "3.0.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-                    "dev": true,
-                    "requires": {
-                        "natives": "^1.1.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "strip-bom": {
+                "clone-stats": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-                    "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-                    "dev": true,
-                    "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "is-utf8": "^0.2.0"
-                    }
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
                 },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
                 },
                 "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true,
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -6329,7 +6495,6 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -6337,8 +6502,7 @@
         "which-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-            "dev": true
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
         },
         "wide-align": {
             "version": "1.1.3",
@@ -6359,7 +6523,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1"
@@ -6368,8 +6531,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
             "version": "6.1.4",
@@ -6389,14 +6551,12 @@
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-            "dev": true
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         },
         "y18n": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-            "dev": true
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
         },
         "yallist": {
             "version": "2.1.2",

--- a/lesson03/activity/package.json
+++ b/lesson03/activity/package.json
@@ -10,7 +10,7 @@
     "license": "ISC",
     "devDependencies": {
         "browser-sync": "^2.26.5",
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.2",
         "gulp-autoprefixer": "^6.1.0",
         "gulp-minify-css": "^1.2.4",
         "gulp-plumber": "^1.2.0",

--- a/lesson03/assignment/gulpfile.js
+++ b/lesson03/assignment/gulpfile.js
@@ -1,14 +1,12 @@
-var gulp = require('gulp'),
+const {dest, series, src, watch} = require('gulp'),
     sass = require('gulp-sass'),
     autoprefix = require('gulp-autoprefixer'),
-    watch = require('gulp-watch'),
     plumber = require('gulp-plumber'),
     gutil = require('gulp-util'),
-    minifycss = require('gulp-minify-css'),
-    browserSync = require('browser-sync').create();
+    browserSync = require('browser-sync').create()
 
-gulp.task('sass', function() {
-    gulp.src('css/*.scss')
+function compileSass() {
+    return src('css/*.scss')
         .pipe(plumber())
         .pipe(sass())
         .pipe(
@@ -16,23 +14,19 @@ gulp.task('sass', function() {
                 browsers: ['> .5%'],
             })
         )
-        .pipe(minifycss({ compatibility: 'ie8' }))
-        .pipe(gulp.dest('css/'))
+        .pipe(dest('css/'))
         .pipe(browserSync.stream());
-});
+}
 
-gulp.task('watch', function() {
-    gulp.watch('css/*.scss', ['sass']);
-    gulp.watch('*.html').on('change', browserSync.reload);
-});
-
-gulp.task('browser-sync', function() {
+function browserSyncs() {
     browserSync.init({
         notify: false,
         server: {
             baseDir: './',
         },
-    });
-});
+    })
+    watch(['css/*.scss']).on('change', compileSass)
+    watch(['*.html']).on('change', browserSync.reload)
+}
 
-gulp.task('default', ['watch', 'browser-sync']);
+exports.default = browserSyncs

--- a/lesson03/assignment/package-lock.json
+++ b/lesson03/assignment/package-lock.json
@@ -48,7 +48,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-            "dev": true,
             "requires": {
                 "ansi-wrap": "^0.1.0"
             }
@@ -66,7 +65,6 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-            "dev": true,
             "requires": {
                 "ansi-wrap": "0.1.0"
             }
@@ -83,8 +81,7 @@
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "dev": true
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
             "version": "2.2.1",
@@ -95,14 +92,12 @@
         "ansi-wrap": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-            "dev": true
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
         },
         "anymatch": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-            "dev": true,
             "requires": {
                 "micromatch": "^3.1.4",
                 "normalize-path": "^2.1.1"
@@ -112,11 +107,18 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-                    "dev": true,
                     "requires": {
                         "remove-trailing-separator": "^1.0.1"
                     }
                 }
+            }
+        },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "requires": {
+                "buffer-equal": "^1.0.0"
             }
         },
         "aproba": {
@@ -128,8 +130,7 @@
         "archy": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-            "dev": true
+            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "are-we-there-yet": {
             "version": "1.1.5",
@@ -144,20 +145,33 @@
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-            "dev": true
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "arr-filter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+            "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
         },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-            "dev": true
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+            "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
         },
         "arr-union": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-            "dev": true
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
         },
         "array-differ": {
             "version": "1.0.0",
@@ -168,8 +182,7 @@
         "array-each": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-            "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
-            "dev": true
+            "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
         },
         "array-find-index": {
             "version": "1.0.2",
@@ -177,11 +190,58 @@
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
+        "array-initial": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+            "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+            "requires": {
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                }
+            }
+        },
+        "array-last": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+            "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+            "requires": {
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                }
+            }
+        },
         "array-slice": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
-            "dev": true
+            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+        },
+        "array-sort": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+            "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+            "requires": {
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -192,8 +252,7 @@
         "array-unique": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-            "dev": true
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "arraybuffer.slice": {
             "version": "0.0.7",
@@ -219,8 +278,7 @@
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-            "dev": true
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
         },
         "async": {
             "version": "1.5.2",
@@ -228,11 +286,21 @@
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
+        "async-done": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+            "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^2.0.0",
+                "stream-exhaust": "^1.0.1"
+            }
+        },
         "async-each": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-            "dev": true
+            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
         },
         "async-each-series": {
             "version": "0.1.1",
@@ -252,6 +320,14 @@
             "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
         },
+        "async-settle": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+            "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+            "requires": {
+                "async-done": "^1.2.2"
+            }
+        },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -261,8 +337,7 @@
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "dev": true
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
         "autoprefixer": {
             "version": "9.5.1",
@@ -300,6 +375,22 @@
                 "is-buffer": "^1.1.5"
             }
         },
+        "bach": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+            "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+            "requires": {
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
+            }
+        },
         "backo2": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -309,14 +400,12 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-            "dev": true,
             "requires": {
                 "cache-base": "^1.0.1",
                 "class-utils": "^0.3.5",
@@ -331,7 +420,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -340,7 +428,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -349,7 +436,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -358,7 +444,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -412,8 +497,7 @@
         "binary-extensions": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-            "dev": true
+            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
         },
         "blob": {
             "version": "0.0.5",
@@ -434,7 +518,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -444,7 +527,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-            "dev": true,
             "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -462,7 +544,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -556,6 +637,16 @@
             "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
             "dev": true
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
         "bufferstreams": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.0.1.tgz",
@@ -601,7 +692,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-            "dev": true,
             "requires": {
                 "collection-visit": "^1.0.0",
                 "component-emitter": "^1.2.1",
@@ -623,8 +713,7 @@
         "camelcase": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-            "dev": true
+            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         },
         "camelcase-keys": {
             "version": "2.1.0",
@@ -673,7 +762,6 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
             "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
-            "dev": true,
             "requires": {
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
@@ -693,7 +781,6 @@
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "define-property": "^0.2.5",
@@ -705,7 +792,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -746,7 +832,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1",
@@ -762,8 +847,7 @@
         "clone-buffer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-            "dev": true
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
         },
         "clone-stats": {
             "version": "0.0.1",
@@ -775,7 +859,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "process-nextick-args": "^2.0.0",
@@ -785,14 +868,22 @@
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "dev": true
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "collection-map": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+            "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+            "requires": {
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            }
         },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-            "dev": true,
             "requires": {
                 "map-visit": "^1.0.0",
                 "object-visit": "^1.0.0"
@@ -816,8 +907,7 @@
         "color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "dev": true
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
         },
         "combined-stream": {
             "version": "1.0.7",
@@ -843,8 +933,7 @@
         "component-emitter": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-            "dev": true
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "component-inherit": {
             "version": "0.0.3",
@@ -855,8 +944,18 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
         },
         "connect": {
             "version": "3.6.6",
@@ -893,6 +992,14 @@
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -902,14 +1009,21 @@
         "copy-descriptor": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-            "dev": true
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "copy-props": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+            "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+            "requires": {
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cross-spawn": {
             "version": "3.0.1",
@@ -942,6 +1056,15 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -969,29 +1092,45 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-            "dev": true
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-            "dev": true
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
-        "defaults": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-            "dev": true,
+        "default-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+            "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "requires": {
-                "clone": "^1.0.2"
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+            }
+        },
+        "default-resolution": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ="
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "requires": {
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-            "dev": true,
             "requires": {
                 "is-descriptor": "^1.0.2",
                 "isobject": "^3.0.1"
@@ -1001,7 +1140,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1010,7 +1148,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1019,7 +1156,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -1046,12 +1182,6 @@
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
         },
-        "deprecated": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-            "dev": true
-        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1061,8 +1191,7 @@
         "detect-file": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-            "dev": true
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
         },
         "dev-ip": {
             "version": "1.0.1",
@@ -1103,6 +1232,26 @@
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                     "dev": true
                 }
+            }
+        },
+        "duplexify": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "requires": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "each-props": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+            "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+            "requires": {
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
             }
         },
         "easy-extender": {
@@ -1152,12 +1301,21 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-            "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
-            "dev": true,
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "requires": {
-                "once": "~1.3.0"
+                "once": "^1.4.0"
+            },
+            "dependencies": {
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                }
             }
         },
         "engine.io": {
@@ -1223,9 +1381,48 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -1256,7 +1453,6 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-            "dev": true,
             "requires": {
                 "debug": "^2.3.3",
                 "define-property": "^0.2.5",
@@ -1271,7 +1467,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -1280,7 +1475,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -1289,7 +1483,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -1357,22 +1550,34 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-            "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+                }
             }
         },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "dev": true
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extend-shallow": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-            "dev": true,
             "requires": {
                 "assign-symbols": "^1.0.0",
                 "is-extendable": "^1.0.1"
@@ -1382,7 +1587,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -1393,7 +1597,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-            "dev": true,
             "requires": {
                 "array-unique": "^0.3.2",
                 "define-property": "^1.0.0",
@@ -1409,7 +1612,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -1418,7 +1620,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -1427,7 +1628,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1436,7 +1636,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1445,7 +1644,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -1464,7 +1662,6 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
             "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
-            "dev": true,
             "requires": {
                 "ansi-gray": "^0.1.1",
                 "color-support": "^1.1.3",
@@ -1494,7 +1691,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-number": "^3.0.0",
@@ -1506,7 +1702,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -1539,50 +1734,30 @@
                 }
             }
         },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-            "dev": true
-        },
         "find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-            "dev": true,
             "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
-            "dev": true,
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+            "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
             "requires": {
                 "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
+                "is-glob": "^4.0.0",
                 "micromatch": "^3.0.4",
                 "resolve-dir": "^1.0.1"
-            },
-            "dependencies": {
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                }
             }
         },
         "fined": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
             "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
-            "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.2",
                 "is-plain-object": "^2.0.3",
@@ -1591,17 +1766,19 @@
                 "parse-filepath": "^1.0.1"
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
         "flagged-respawn": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
-            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
-            "dev": true
+            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
+        },
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
+            }
         },
         "follow-redirects": {
             "version": "1.7.0",
@@ -1632,14 +1809,12 @@
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "for-own": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
             "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-            "dev": true,
             "requires": {
                 "for-in": "^1.0.1"
             }
@@ -1665,7 +1840,6 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-            "dev": true,
             "requires": {
                 "map-cache": "^0.2.2"
             }
@@ -1687,17 +1861,24 @@
                 "universalify": "^0.1.0"
             }
         },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
             "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "nan": "^2.12.1",
@@ -1707,25 +1888,21 @@
                 "abbrev": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "delegates": "^1.0.0",
@@ -1735,13 +1912,11 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
@@ -1751,37 +1926,31 @@
                 "chownr": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "debug": {
                     "version": "4.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -1790,25 +1959,21 @@
                 "deep-extend": {
                     "version": "0.6.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -1817,13 +1982,11 @@
                 "fs.realpath": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "aproba": "^1.0.3",
@@ -1839,7 +2002,6 @@
                 "glob": {
                     "version": "7.1.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -1853,13 +2015,11 @@
                 "has-unicode": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.24",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
@@ -1868,7 +2028,6 @@
                 "ignore-walk": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minimatch": "^3.0.4"
@@ -1877,7 +2036,6 @@
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "once": "^1.3.0",
@@ -1887,19 +2045,16 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
@@ -1908,13 +2063,11 @@
                 "isarray": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
@@ -1923,13 +2076,11 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
@@ -1939,7 +2090,6 @@
                 "minizlib": {
                     "version": "1.2.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -1948,7 +2098,6 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
@@ -1957,13 +2106,11 @@
                 "ms": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "needle": {
                     "version": "2.3.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "debug": "^4.1.0",
@@ -1974,7 +2121,6 @@
                 "node-pre-gyp": {
                     "version": "0.12.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
@@ -1992,7 +2138,6 @@
                 "nopt": {
                     "version": "4.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "abbrev": "1",
@@ -2002,13 +2147,11 @@
                 "npm-bundled": {
                     "version": "1.0.6",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.4.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ignore-walk": "^3.0.1",
@@ -2018,7 +2161,6 @@
                 "npmlog": {
                     "version": "4.1.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "are-we-there-yet": "~1.1.2",
@@ -2030,19 +2172,16 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "wrappy": "1"
@@ -2051,19 +2190,16 @@
                 "os-homedir": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "os-homedir": "^1.0.0",
@@ -2073,19 +2209,16 @@
                 "path-is-absolute": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.8",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "deep-extend": "^0.6.0",
@@ -2097,7 +2230,6 @@
                         "minimist": {
                             "version": "1.2.0",
                             "bundled": true,
-                            "dev": true,
                             "optional": true
                         }
                     }
@@ -2105,7 +2237,6 @@
                 "readable-stream": {
                     "version": "2.3.6",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -2120,7 +2251,6 @@
                 "rimraf": {
                     "version": "2.6.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "glob": "^7.1.3"
@@ -2129,43 +2259,36 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "semver": {
                     "version": "5.7.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
@@ -2176,7 +2299,6 @@
                 "string_decoder": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
@@ -2185,7 +2307,6 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
@@ -2194,13 +2315,11 @@
                 "strip-json-comments": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "4.4.8",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "chownr": "^1.1.1",
@@ -2215,13 +2334,11 @@
                 "util-deprecate": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "string-width": "^1.0.2 || 2"
@@ -2230,13 +2347,11 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -2252,6 +2367,11 @@
                 "mkdirp": ">=0.5 0",
                 "rimraf": "2"
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "gauge": {
             "version": "2.7.4",
@@ -2277,20 +2397,10 @@
                 }
             }
         },
-        "gaze": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-            "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-            "dev": true,
-            "requires": {
-                "globule": "~0.1.0"
-            }
-        },
         "get-caller-file": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-            "dev": true
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
         },
         "get-stdin": {
             "version": "4.0.1",
@@ -2301,8 +2411,7 @@
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-            "dev": true
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
         },
         "getpass": {
             "version": "0.1.7",
@@ -2314,26 +2423,16 @@
             }
         },
         "glob": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-            "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-            "dev": true,
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "requires": {
+                "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
-            },
-            "dependencies": {
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                }
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2376,7 +2475,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-            "dev": true,
             "requires": {
                 "is-glob": "^3.1.0",
                 "path-dirname": "^1.0.0"
@@ -2386,7 +2484,6 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.0"
                     }
@@ -2394,87 +2491,39 @@
             }
         },
         "glob-stream": {
-            "version": "3.1.18",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-            "dev": true,
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-            "dev": true,
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+            "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
             "requires": {
-                "gaze": "^0.5.1"
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "dev": true,
-            "requires": {
-                "find-index": "^0.1.1"
+                "anymatch": "^2.0.0",
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "is-negated-glob": "^1.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-            "dev": true,
             "requires": {
                 "global-prefix": "^1.0.1",
                 "is-windows": "^1.0.1",
@@ -2485,7 +2534,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-            "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.2",
                 "homedir-polyfill": "^1.0.1",
@@ -2494,63 +2542,10 @@
                 "which": "^1.2.14"
             }
         },
-        "globule": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-            "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-            "dev": true,
-            "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "3.1.21",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-                    "dev": true
-                },
-                "inherits": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                    "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "0.2.14",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
-                    }
-                }
-            }
-        },
         "glogg": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
             "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
-            "dev": true,
             "requires": {
                 "sparkles": "^1.0.0"
             }
@@ -2558,8 +2553,7 @@
         "graceful-fs": {
             "version": "4.1.15",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-            "dev": true
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
         },
         "graceful-readlink": {
             "version": "1.0.1",
@@ -2568,31 +2562,68 @@
             "dev": true
         },
         "gulp": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-            "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
-            "dev": true,
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+            "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
+                "glob-watcher": "^5.0.3",
+                "gulp-cli": "^2.2.0",
+                "undertaker": "^1.2.1",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-                    "dev": true
+                "gulp-cli": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+                    "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+                    "requires": {
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^3.1.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
                 }
             }
         },
@@ -2984,7 +3015,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true,
             "requires": {
                 "glogg": "^1.0.0"
             }
@@ -3044,6 +3074,11 @@
                 "sparkles": "^1.0.0"
             }
         },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+        },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3054,7 +3089,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-            "dev": true,
             "requires": {
                 "get-value": "^2.0.6",
                 "has-values": "^1.0.0",
@@ -3065,7 +3099,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "kind-of": "^4.0.0"
@@ -3075,7 +3108,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3086,7 +3118,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
             "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-            "dev": true,
             "requires": {
                 "parse-passwd": "^1.0.0"
             }
@@ -3094,8 +3125,7 @@
         "hosted-git-info": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-            "dev": true
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
         },
         "http-errors": {
             "version": "1.7.2",
@@ -3179,7 +3209,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -3188,32 +3217,27 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-            "dev": true
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "interpret": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-            "dev": true
+            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
         },
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-            "dev": true
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
         },
         "is-absolute": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-            "dev": true,
             "requires": {
                 "is-relative": "^1.0.0",
                 "is-windows": "^1.0.1"
@@ -3223,7 +3247,6 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -3232,7 +3255,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3242,14 +3264,12 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "is-binary-path": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-            "dev": true,
             "requires": {
                 "binary-extensions": "^1.0.0"
             }
@@ -3257,14 +3277,12 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-data-descriptor": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -3273,7 +3291,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3284,7 +3301,6 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-            "dev": true,
             "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -3294,8 +3310,7 @@
                 "kind-of": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
                 }
             }
         },
@@ -3317,14 +3332,12 @@
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
         },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-finite": {
             "version": "1.0.2",
@@ -3339,7 +3352,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "dev": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -3348,16 +3360,19 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
+        },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
         },
         "is-number": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -3366,7 +3381,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3386,7 +3400,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -3407,7 +3420,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-            "dev": true,
             "requires": {
                 "is-unc-path": "^1.0.0"
             }
@@ -3422,7 +3434,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-            "dev": true,
             "requires": {
                 "unc-path-regex": "^0.1.2"
             }
@@ -3430,14 +3441,17 @@
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-            "dev": true
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+        },
+        "is-valid-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
         },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-            "dev": true
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         },
         "is-wsl": {
             "version": "1.1.0",
@@ -3454,14 +3468,12 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-            "dev": true
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "isstream": {
             "version": "0.1.2",
@@ -3493,6 +3505,11 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3520,29 +3537,56 @@
                 "verror": "1.10.0"
             }
         },
+        "just-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
+        },
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-            "dev": true
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        },
+        "last-run": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+            "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+            "requires": {
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "requires": {
+                "readable-stream": "^2.0.5"
+            }
         },
         "lcid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-            "dev": true,
             "requires": {
                 "invert-kv": "^1.0.0"
             }
         },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "requires": {
+                "flush-write-stream": "^1.0.2"
+            }
+        },
         "liftoff": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
-            "dev": true,
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+            "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
             "requires": {
                 "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
+                "findup-sync": "^3.0.0",
                 "fined": "^1.0.1",
                 "flagged-respawn": "^1.0.0",
                 "is-plain-object": "^2.0.4",
@@ -3561,7 +3605,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -3761,17 +3804,10 @@
                 "signal-exit": "^3.0.0"
             }
         },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-            "dev": true
-        },
         "make-iterator": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
             "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
-            "dev": true,
             "requires": {
                 "kind-of": "^6.0.2"
             }
@@ -3779,8 +3815,7 @@
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-            "dev": true
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
         },
         "map-obj": {
             "version": "1.0.1",
@@ -3792,9 +3827,40 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-            "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
+            }
+        },
+        "matchdep": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+            "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+            "requires": {
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
+                "stack-trace": "0.0.10"
+            },
+            "dependencies": {
+                "findup-sync": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+                    "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^3.1.0",
+                        "micromatch": "^3.0.4",
+                        "resolve-dir": "^1.0.1"
+                    }
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                }
             }
         },
         "math-random": {
@@ -3833,7 +3899,6 @@
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -3875,7 +3940,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -3896,7 +3960,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
             "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-            "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
                 "is-extendable": "^1.0.1"
@@ -3906,7 +3969,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -3933,8 +3995,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "multipipe": {
             "version": "0.1.2",
@@ -3945,17 +4006,20 @@
                 "duplexer2": "0.0.2"
             }
         },
+        "mute-stdout": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg=="
+        },
         "nan": {
             "version": "2.13.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-            "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
-            "dev": true
+            "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
         },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -3970,17 +4034,16 @@
                 "to-regex": "^3.0.1"
             }
         },
-        "natives": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-            "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-            "dev": true
-        },
         "negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
             "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node-gyp": {
             "version": "3.8.0",
@@ -4107,7 +4170,6 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "resolve": "^1.10.0",
@@ -4118,14 +4180,21 @@
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "normalize-range": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
+        },
+        "now-and-later": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+            "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+            "requires": {
+                "once": "^1.3.2"
+            }
         },
         "npmlog": {
             "version": "4.1.2",
@@ -4148,8 +4217,7 @@
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "oauth-sign": {
             "version": "0.9.0",
@@ -4173,7 +4241,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-            "dev": true,
             "requires": {
                 "copy-descriptor": "^0.1.0",
                 "define-property": "^0.2.5",
@@ -4184,7 +4251,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -4193,12 +4259,16 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
                 }
             }
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "object-path": {
             "version": "0.9.2",
@@ -4210,16 +4280,25 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
-            "dev": true,
             "requires": {
                 "array-each": "^1.0.1",
                 "array-slice": "^1.0.0",
@@ -4231,7 +4310,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
-            "dev": true,
             "requires": {
                 "for-own": "^1.0.0",
                 "make-iterator": "^1.0.0"
@@ -4262,9 +4340,17 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
+            }
+        },
+        "object.reduce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+            "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "on-finished": {
@@ -4280,7 +4366,6 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
             "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -4300,22 +4385,13 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "orchestrator": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
-            }
-        },
         "ordered-read-streams": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-            "dev": true
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+            "requires": {
+                "readable-stream": "^2.0.1"
+            }
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -4327,7 +4403,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-            "dev": true,
             "requires": {
                 "lcid": "^1.0.0"
             }
@@ -4352,7 +4427,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
-            "dev": true,
             "requires": {
                 "is-absolute": "^1.0.0",
                 "map-cache": "^0.2.0",
@@ -4392,7 +4466,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "dev": true,
             "requires": {
                 "error-ex": "^1.2.0"
             }
@@ -4400,14 +4473,12 @@
         "parse-node-version": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-            "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-            "dev": true
+            "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
         },
         "parse-passwd": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-            "dev": true
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
         },
         "parseqs": {
             "version": "0.0.5",
@@ -4436,20 +4507,17 @@
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-            "dev": true
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
         },
         "path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-            "dev": true
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
         "path-exists": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "dev": true,
             "requires": {
                 "pinkie-promise": "^2.0.0"
             }
@@ -4457,20 +4525,17 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-parse": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-            "dev": true
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "path-root": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-            "dev": true,
             "requires": {
                 "path-root-regex": "^0.1.0"
             }
@@ -4478,14 +4543,12 @@
         "path-root-regex": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
-            "dev": true
+            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
         },
         "path-type": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "pify": "^2.0.0",
@@ -4501,20 +4564,17 @@
         "pify": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
             "requires": {
                 "pinkie": "^2.0.0"
             }
@@ -4544,8 +4604,7 @@
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-            "dev": true
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "postcss": {
             "version": "7.0.16",
@@ -4621,14 +4680,12 @@
         "pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-            "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-            "dev": true
+            "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
         },
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-            "dev": true
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "pseudomap": {
             "version": "1.0.2",
@@ -4641,6 +4698,25 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
             "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
+        },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
         },
         "punycode": {
             "version": "2.1.1",
@@ -4695,7 +4771,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-            "dev": true,
             "requires": {
                 "load-json-file": "^1.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -4706,7 +4781,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-            "dev": true,
             "requires": {
                 "find-up": "^1.0.0",
                 "read-pkg": "^1.0.0"
@@ -4716,7 +4790,6 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -4730,8 +4803,7 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 }
             }
         },
@@ -4739,7 +4811,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
             "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11",
                 "micromatch": "^3.1.10",
@@ -4750,7 +4821,6 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dev": true,
             "requires": {
                 "resolve": "^1.1.6"
             }
@@ -4778,29 +4848,44 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
             }
         },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-            "dev": true
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
         },
         "repeat-element": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-            "dev": true
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
         },
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "repeating": {
             "version": "2.0.1",
@@ -4816,6 +4901,16 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
             "dev": true
+        },
+        "replace-homedir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+            "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+            "requires": {
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
+            }
         },
         "request": {
             "version": "2.88.0",
@@ -4856,14 +4951,12 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-            "dev": true
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
         "require-main-filename": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-            "dev": true
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
         "requires-port": {
             "version": "1.0.0",
@@ -4875,7 +4968,6 @@
             "version": "1.10.1",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
             "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
-            "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
             }
@@ -4884,17 +4976,23 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-            "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.0",
                 "global-modules": "^1.0.0"
             }
         },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "requires": {
+                "value-or-function": "^3.0.0"
+            }
+        },
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-            "dev": true
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "resp-modifier": {
             "version": "6.0.2",
@@ -4920,8 +5018,7 @@
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-            "dev": true
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
         },
         "rimraf": {
             "version": "2.6.3",
@@ -4966,14 +5063,12 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safe-regex": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-            "dev": true,
             "requires": {
                 "ret": "~0.1.10"
             }
@@ -5066,8 +5161,15 @@
         "semver": {
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-            "dev": true
+            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        },
+        "semver-greatest-satisfied-range": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+            "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+            "requires": {
+                "sver-compat": "^1.5.0"
+            }
         },
         "send": {
             "version": "0.16.2",
@@ -5124,12 +5226,6 @@
                     "dev": true
                 }
             }
-        },
-        "sequencify": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-            "dev": true
         },
         "serve-index": {
             "version": "1.9.1",
@@ -5202,14 +5298,12 @@
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-            "dev": true
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "set-value": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-extendable": "^0.1.1",
@@ -5221,7 +5315,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -5232,12 +5325,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-            "dev": true
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
             "dev": true
         },
         "signal-exit": {
@@ -5256,7 +5343,6 @@
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-            "dev": true,
             "requires": {
                 "base": "^0.11.1",
                 "debug": "^2.2.0",
@@ -5272,7 +5358,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -5281,7 +5366,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -5290,7 +5374,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -5301,7 +5384,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-            "dev": true,
             "requires": {
                 "define-property": "^1.0.0",
                 "isobject": "^3.0.0",
@@ -5312,7 +5394,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -5321,7 +5402,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5330,7 +5410,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5339,7 +5418,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -5352,7 +5430,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.2.0"
             },
@@ -5361,7 +5438,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -5489,14 +5565,12 @@
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-resolve": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-            "dev": true,
             "requires": {
                 "atob": "^2.1.1",
                 "decode-uri-component": "^0.2.0",
@@ -5508,20 +5582,17 @@
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-            "dev": true
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
         "sparkles": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
-            "dev": true
+            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
         },
         "spdx-correct": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
             "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-            "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -5530,14 +5601,12 @@
         "spdx-exceptions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-            "dev": true
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-            "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -5546,14 +5615,12 @@
         "spdx-license-ids": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
-            "dev": true
+            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
         },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
             }
@@ -5575,11 +5642,15 @@
                 "tweetnacl": "~0.14.0"
             }
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-            "dev": true,
             "requires": {
                 "define-property": "^0.2.5",
                 "object-copy": "^0.1.0"
@@ -5589,7 +5660,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -5611,11 +5681,15 @@
                 "readable-stream": "^2.0.1"
             }
         },
-        "stream-consume": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-            "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
-            "dev": true
+        "stream-exhaust": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw=="
+        },
+        "stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
         },
         "stream-throttle": {
             "version": "0.1.3",
@@ -5631,7 +5705,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "dev": true,
             "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5642,7 +5715,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -5651,7 +5723,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -5660,7 +5731,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
             "requires": {
                 "is-utf8": "^0.2.0"
             }
@@ -5701,6 +5771,15 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "sver-compat": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+            "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+            "requires": {
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "symbol-observable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -5732,26 +5811,33 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-            "dev": true,
             "requires": {
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
             }
         },
-        "tildify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-            "dev": true,
+        "through2-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "requires": {
-                "os-homedir": "^1.0.0"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-            "dev": true
+            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+        },
+        "to-absolute-glob": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
+            }
         },
         "to-array": {
             "version": "0.1.4",
@@ -5763,7 +5849,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -5772,7 +5857,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -5783,7 +5867,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-            "dev": true,
             "requires": {
                 "define-property": "^2.0.2",
                 "extend-shallow": "^3.0.2",
@@ -5795,10 +5878,17 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
+            }
+        },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "requires": {
+                "through2": "^2.0.3"
             }
         },
         "toidentifier": {
@@ -5871,6 +5961,16 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+        },
         "ua-parser-js": {
             "version": "0.7.17",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -5886,14 +5986,33 @@
         "unc-path-regex": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-            "dev": true
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+        },
+        "undertaker": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+            "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+            "requires": {
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
+            }
+        },
+        "undertaker-registry": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA="
         },
         "union-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
@@ -5905,7 +6024,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -5914,7 +6032,6 @@
                     "version": "0.4.3",
                     "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-extendable": "^0.1.1",
@@ -5925,10 +6042,13 @@
             }
         },
         "unique-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-            "dev": true
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+            "requires": {
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
+            }
         },
         "universalify": {
             "version": "0.1.2",
@@ -5946,7 +6066,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-            "dev": true,
             "requires": {
                 "has-value": "^0.3.1",
                 "isobject": "^3.0.0"
@@ -5956,7 +6075,6 @@
                     "version": "0.3.1",
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-                    "dev": true,
                     "requires": {
                         "get-value": "^2.0.3",
                         "has-values": "^0.1.4",
@@ -5967,7 +6085,6 @@
                             "version": "2.1.0",
                             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                            "dev": true,
                             "requires": {
                                 "isarray": "1.0.0"
                             }
@@ -5977,22 +6094,19 @@
                 "has-values": {
                     "version": "0.1.4",
                     "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-                    "dev": true
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
                 },
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 }
             }
         },
         "upath": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
-            "dev": true
+            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q=="
         },
         "uri-js": {
             "version": "4.2.2",
@@ -6006,26 +6120,17 @@
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-            "dev": true
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
         "use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-            "dev": true
-        },
-        "user-home": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-            "dev": true
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
         },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "utils-merge": {
             "version": "1.0.1",
@@ -6040,23 +6145,26 @@
             "dev": true
         },
         "v8flags": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-            "dev": true,
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+            "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
             "requires": {
-                "user-home": "^1.1.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM="
         },
         "verror": {
             "version": "1.10.0",
@@ -6117,88 +6225,107 @@
             }
         },
         "vinyl-fs": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
-            "dev": true,
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
                 },
-                "graceful-fs": {
-                    "version": "3.0.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-                    "dev": true,
-                    "requires": {
-                        "natives": "^1.1.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "strip-bom": {
+                "clone-stats": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-                    "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-                    "dev": true,
-                    "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "is-utf8": "^0.2.0"
-                    }
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
                 },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
                 },
                 "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true,
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -6216,7 +6343,6 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -6224,8 +6350,7 @@
         "which-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-            "dev": true
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
         },
         "wide-align": {
             "version": "1.1.3",
@@ -6246,7 +6371,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1"
@@ -6255,8 +6379,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
             "version": "6.1.4",
@@ -6276,14 +6399,12 @@
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-            "dev": true
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         },
         "y18n": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-            "dev": true
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
         },
         "yallist": {
             "version": "2.1.2",

--- a/lesson03/assignment/package.json
+++ b/lesson03/assignment/package.json
@@ -10,7 +10,7 @@
     "license": "ISC",
     "devDependencies": {
         "browser-sync": "^2.26.5",
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.2",
         "gulp-autoprefixer": "^6.1.0",
         "gulp-minify-css": "^1.2.4",
         "gulp-plumber": "^1.2.0",

--- a/lesson04/activity/gulpfile.js
+++ b/lesson04/activity/gulpfile.js
@@ -1,13 +1,12 @@
-var gulp = require('gulp'),
+const {dest, series, src, watch} = require('gulp'),
     sass = require('gulp-sass'),
     autoprefix = require('gulp-autoprefixer'),
-    watch = require('gulp-watch'),
     plumber = require('gulp-plumber'),
     gutil = require('gulp-util'),
-    browserSync = require('browser-sync').create();
+    browserSync = require('browser-sync').create()
 
-gulp.task('sass', function() {
-    gulp.src('css/*.scss')
+function compileSass() {
+    return src('css/*.scss')
         .pipe(plumber())
         .pipe(sass())
         .pipe(
@@ -15,22 +14,19 @@ gulp.task('sass', function() {
                 browsers: ['> .5%'],
             })
         )
-        .pipe(gulp.dest('css/'))
+        .pipe(dest('css/'))
         .pipe(browserSync.stream());
-});
+}
 
-gulp.task('watch', function() {
-    gulp.watch('css/*.scss', ['sass']);
-    gulp.watch('*.html').on('change', browserSync.reload);
-});
-
-gulp.task('browser-sync', function() {
+function browserSyncs() {
     browserSync.init({
         notify: false,
         server: {
             baseDir: './',
         },
-    });
-});
+    })
+    watch(['css/*.scss']).on('change', compileSass)
+    watch(['*.html']).on('change', browserSync.reload)
+}
 
-gulp.task('default', ['watch', 'browser-sync']);
+exports.default = browserSyncs

--- a/lesson04/activity/package-lock.json
+++ b/lesson04/activity/package-lock.json
@@ -119,6 +119,15 @@
                 }
             }
         },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "dev": true,
+            "requires": {
+                "buffer-equal": "^1.0.0"
+            }
+        },
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -147,11 +156,29 @@
             "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
             "dev": true
         },
+        "arr-filter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+            "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
+        },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
+        },
+        "arr-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+            "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
         },
         "arr-union": {
             "version": "3.1.0",
@@ -177,11 +204,65 @@
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
+        "array-initial": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+            "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+            "dev": true,
+            "requires": {
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "array-last": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+            "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+            "dev": true,
+            "requires": {
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
         "array-slice": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
             "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
             "dev": true
+        },
+        "array-sort": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+            "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+            "dev": true,
+            "requires": {
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -228,6 +309,18 @@
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
+        "async-done": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+            "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^2.0.0",
+                "stream-exhaust": "^1.0.1"
+            }
+        },
         "async-each": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -251,6 +344,15 @@
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
             "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
+        },
+        "async-settle": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+            "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+            "dev": true,
+            "requires": {
+                "async-done": "^1.2.2"
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -298,6 +400,23 @@
             "requires": {
                 "follow-redirects": "^1.2.5",
                 "is-buffer": "^1.1.5"
+            }
+        },
+        "bach": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+            "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+            "dev": true,
+            "requires": {
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "backo2": {
@@ -555,6 +674,18 @@
             "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
             "dev": true
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
         "bufferstreams": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.0.1.tgz",
@@ -787,6 +918,17 @@
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
+        "collection-map": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+            "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+            "dev": true,
+            "requires": {
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            }
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -857,6 +999,18 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
         "connect": {
             "version": "3.6.6",
             "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -892,6 +1046,15 @@
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -903,6 +1066,16 @@
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
+        },
+        "copy-props": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+            "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+            "dev": true,
+            "requires": {
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -941,6 +1114,16 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -977,13 +1160,36 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
-        "defaults": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+        "default-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+            "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "clone": "^1.0.2"
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "default-resolution": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+            "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -1045,12 +1251,6 @@
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
         },
-        "deprecated": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-            "dev": true
-        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1104,6 +1304,28 @@
                 }
             }
         },
+        "duplexify": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "each-props": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+            "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
+            }
+        },
         "easy-extender": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
@@ -1151,12 +1373,23 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-            "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
             "requires": {
-                "once": "~1.3.0"
+                "once": "^1.4.0"
+            },
+            "dependencies": {
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                }
             }
         },
         "engine.io": {
@@ -1225,6 +1458,50 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -1359,6 +1636,23 @@
             "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -1538,12 +1832,6 @@
                 }
             }
         },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-            "dev": true
-        },
         "find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -1555,26 +1843,15 @@
             }
         },
         "findup-sync": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+            "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
             "dev": true,
             "requires": {
                 "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
+                "is-glob": "^4.0.0",
                 "micromatch": "^3.0.4",
                 "resolve-dir": "^1.0.1"
-            },
-            "dependencies": {
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                }
             }
         },
         "fined": {
@@ -1590,17 +1867,21 @@
                 "parse-filepath": "^1.0.1"
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
         "flagged-respawn": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
             "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
             "dev": true
+        },
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
+            }
         },
         "follow-redirects": {
             "version": "1.7.0",
@@ -1684,6 +1965,16 @@
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^3.0.0",
                 "universalify": "^0.1.0"
+            }
+        },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs.realpath": {
@@ -2252,6 +2543,12 @@
                 "rimraf": "2"
             }
         },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
         "gauge": {
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -2274,15 +2571,6 @@
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true
                 }
-            }
-        },
-        "gaze": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-            "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-            "dev": true,
-            "requires": {
-                "globule": "~0.1.0"
             }
         },
         "get-caller-file": {
@@ -2313,26 +2601,17 @@
             }
         },
         "glob": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-            "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "dev": true,
             "requires": {
+                "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
-            },
-            "dependencies": {
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                }
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2393,80 +2672,35 @@
             }
         },
         "glob-stream": {
-            "version": "3.1.18",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+            "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
             "dev": true,
             "requires": {
-                "gaze": "^0.5.1"
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "dev": true,
-            "requires": {
-                "find-index": "^0.1.1"
+                "anymatch": "^2.0.0",
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "is-negated-glob": "^1.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
@@ -2493,58 +2727,6 @@
                 "which": "^1.2.14"
             }
         },
-        "globule": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-            "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-            "dev": true,
-            "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "3.1.21",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-                    "dev": true
-                },
-                "inherits": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                    "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "0.2.14",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
-                    }
-                }
-            }
-        },
         "glogg": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -2567,31 +2749,72 @@
             "dev": true
         },
         "gulp": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-            "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+            "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
+                "glob-watcher": "^5.0.3",
+                "gulp-cli": "^2.2.0",
+                "undertaker": "^1.2.1",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-                    "dev": true
+                "gulp-cli": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+                    "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^3.1.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
                 }
             }
         },
@@ -2945,6 +3168,12 @@
                 "sparkles": "^1.0.0"
             }
         },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
+        },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3254,6 +3483,12 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+            "dev": true
+        },
         "is-number": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3334,6 +3569,12 @@
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
+        "is-valid-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+            "dev": true
+        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3394,6 +3635,12 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3421,11 +3668,36 @@
                 "verror": "1.10.0"
             }
         },
+        "just-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+            "dev": true
+        },
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
             "dev": true
+        },
+        "last-run": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+            "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+            "dev": true,
+            "requires": {
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.5"
+            }
         },
         "lcid": {
             "version": "1.0.0",
@@ -3436,14 +3708,23 @@
                 "invert-kv": "^1.0.0"
             }
         },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "dev": true,
+            "requires": {
+                "flush-write-stream": "^1.0.2"
+            }
+        },
         "liftoff": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+            "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
             "dev": true,
             "requires": {
                 "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
+                "findup-sync": "^3.0.0",
                 "fined": "^1.0.1",
                 "flagged-respawn": "^1.0.0",
                 "is-plain-object": "^2.0.4",
@@ -3674,12 +3955,6 @@
                 "signal-exit": "^3.0.0"
             }
         },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-            "dev": true
-        },
         "make-iterator": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -3708,6 +3983,41 @@
             "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
+            }
+        },
+        "matchdep": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+            "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+            "dev": true,
+            "requires": {
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
+                "stack-trace": "0.0.10"
+            },
+            "dependencies": {
+                "findup-sync": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+                    "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "dev": true,
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^3.1.0",
+                        "micromatch": "^3.0.4",
+                        "resolve-dir": "^1.0.1"
+                    }
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                }
             }
         },
         "math-random": {
@@ -3858,6 +4168,12 @@
                 "duplexer2": "0.0.2"
             }
         },
+        "mute-stdout": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+            "dev": true
+        },
         "nan": {
             "version": "2.13.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
@@ -3883,16 +4199,16 @@
                 "to-regex": "^3.0.1"
             }
         },
-        "natives": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-            "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-            "dev": true
-        },
         "negotiator": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
             "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+            "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
         "node-gyp": {
@@ -4033,6 +4349,15 @@
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
         },
+        "now-and-later": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+            "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.2"
+            }
+        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -4106,6 +4431,12 @@
                 }
             }
         },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
         "object-path": {
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
@@ -4119,6 +4450,18 @@
             "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -4173,6 +4516,16 @@
                 "isobject": "^3.0.1"
             }
         },
+        "object.reduce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+            "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            }
+        },
         "on-finished": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4206,22 +4559,14 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "orchestrator": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+        "ordered-read-streams": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
+                "readable-stream": "^2.0.1"
             }
-        },
-        "ordered-read-streams": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-            "dev": true
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -4577,6 +4922,27 @@
             "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
         },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
+        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -4719,6 +5085,27 @@
                 "safe-regex": "^1.1.0"
             }
         },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "dev": true,
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4751,6 +5138,17 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
             "dev": true
+        },
+        "replace-homedir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+            "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
+            }
         },
         "request": {
             "version": "2.88.0",
@@ -4823,6 +5221,15 @@
             "requires": {
                 "expand-tilde": "^2.0.0",
                 "global-modules": "^1.0.0"
+            }
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
+            "requires": {
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -5004,6 +5411,15 @@
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
             "dev": true
         },
+        "semver-greatest-satisfied-range": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+            "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+            "dev": true,
+            "requires": {
+                "sver-compat": "^1.5.0"
+            }
+        },
         "send": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -5059,12 +5475,6 @@
                     "dev": true
                 }
             }
-        },
-        "sequencify": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-            "dev": true
         },
         "serve-index": {
             "version": "1.9.1",
@@ -5167,12 +5577,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-            "dev": true
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
             "dev": true
         },
         "signal-exit": {
@@ -5510,6 +5914,12 @@
                 "tweetnacl": "~0.14.0"
             }
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -5546,10 +5956,16 @@
                 "readable-stream": "^2.0.1"
             }
         },
-        "stream-consume": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-            "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
+        "stream-exhaust": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+            "dev": true
+        },
+        "stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
         "stream-throttle": {
@@ -5636,6 +6052,16 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "sver-compat": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+            "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "symbol-observable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -5673,13 +6099,14 @@
                 "xtend": "~4.0.1"
             }
         },
-        "tildify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+        "through2-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -5687,6 +6114,16 @@
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
             "dev": true
+        },
+        "to-absolute-glob": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+            "dev": true,
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
+            }
         },
         "to-array": {
             "version": "0.1.4",
@@ -5734,6 +6171,15 @@
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
+            }
+        },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.3"
             }
         },
         "toidentifier": {
@@ -5806,6 +6252,18 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
         "ua-parser-js": {
             "version": "0.7.17",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -5822,6 +6280,29 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
+        },
+        "undertaker": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+            "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
+            }
+        },
+        "undertaker-registry": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
             "dev": true
         },
         "union-value": {
@@ -5860,10 +6341,14 @@
             }
         },
         "unique-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-            "dev": true
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
+            }
         },
         "universalify": {
             "version": "0.1.2",
@@ -5950,12 +6435,6 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
-        "user-home": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-            "dev": true
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5975,12 +6454,12 @@
             "dev": true
         },
         "v8flags": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+            "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
             "dev": true,
             "requires": {
-                "user-home": "^1.1.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -5992,6 +6471,12 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -6052,88 +6537,118 @@
             }
         },
         "vinyl-fs": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
                     "dev": true
                 },
-                "graceful-fs": {
-                    "version": "3.0.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-                    "dev": true,
-                    "requires": {
-                        "natives": "^1.1.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "strip-bom": {
+                "clone-stats": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-                    "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-                    "dev": true,
-                    "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "is-utf8": "^0.2.0"
-                    }
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
                 },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
                 },
                 "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }

--- a/lesson04/activity/package.json
+++ b/lesson04/activity/package.json
@@ -10,7 +10,7 @@
     "license": "ISC",
     "devDependencies": {
         "browser-sync": "^2.24.3",
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.2",
         "gulp-autoprefixer": "^4.1.0",
         "gulp-minify-css": "^1.2.4",
         "gulp-plumber": "^1.1.0",

--- a/lesson04/assignment/gulpfile.js
+++ b/lesson04/assignment/gulpfile.js
@@ -1,13 +1,12 @@
-var gulp = require('gulp'),
+const {dest, series, src, watch} = require('gulp'),
     sass = require('gulp-sass'),
     autoprefix = require('gulp-autoprefixer'),
-    watch = require('gulp-watch'),
     plumber = require('gulp-plumber'),
     gutil = require('gulp-util'),
-    browserSync = require('browser-sync').create();
+    browserSync = require('browser-sync').create()
 
-gulp.task('sass', function() {
-    gulp.src('css/*.scss')
+function compileSass() {
+    return src('css/*.scss')
         .pipe(plumber())
         .pipe(sass())
         .pipe(
@@ -15,22 +14,19 @@ gulp.task('sass', function() {
                 browsers: ['> .5%'],
             })
         )
-        .pipe(gulp.dest('css/'))
+        .pipe(dest('css/'))
         .pipe(browserSync.stream());
-});
+}
 
-gulp.task('watch', function() {
-    gulp.watch('css/*.scss', ['sass']);
-    gulp.watch('*.html').on('change', browserSync.reload);
-});
-
-gulp.task('browser-sync', function() {
+function browserSyncs() {
     browserSync.init({
         notify: false,
         server: {
             baseDir: './',
         },
-    });
-});
+    })
+    watch(['css/*.scss']).on('change', compileSass)
+    watch(['*.html']).on('change', browserSync.reload)
+}
 
-gulp.task('default', ['watch', 'browser-sync']);
+exports.default = browserSyncs

--- a/lesson04/assignment/package-lock.json
+++ b/lesson04/assignment/package-lock.json
@@ -119,6 +119,15 @@
                 }
             }
         },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "dev": true,
+            "requires": {
+                "buffer-equal": "^1.0.0"
+            }
+        },
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -147,11 +156,29 @@
             "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
             "dev": true
         },
+        "arr-filter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+            "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
+        },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
+        },
+        "arr-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+            "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
         },
         "arr-union": {
             "version": "3.1.0",
@@ -177,11 +204,65 @@
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
+        "array-initial": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+            "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+            "dev": true,
+            "requires": {
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "array-last": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+            "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+            "dev": true,
+            "requires": {
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
         "array-slice": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
             "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
             "dev": true
+        },
+        "array-sort": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+            "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+            "dev": true,
+            "requires": {
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -228,6 +309,18 @@
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
+        "async-done": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+            "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^2.0.0",
+                "stream-exhaust": "^1.0.1"
+            }
+        },
         "async-each": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -251,6 +344,15 @@
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
             "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
+        },
+        "async-settle": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+            "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+            "dev": true,
+            "requires": {
+                "async-done": "^1.2.2"
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -298,6 +400,23 @@
             "requires": {
                 "follow-redirects": "^1.2.5",
                 "is-buffer": "^1.1.5"
+            }
+        },
+        "bach": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+            "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+            "dev": true,
+            "requires": {
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "backo2": {
@@ -555,6 +674,18 @@
             "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
             "dev": true
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
         "bufferstreams": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.0.1.tgz",
@@ -787,6 +918,17 @@
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
+        "collection-map": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+            "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+            "dev": true,
+            "requires": {
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            }
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -857,6 +999,18 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
         "connect": {
             "version": "3.6.6",
             "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -892,6 +1046,15 @@
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -903,6 +1066,16 @@
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
+        },
+        "copy-props": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+            "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+            "dev": true,
+            "requires": {
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -941,6 +1114,16 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -977,13 +1160,36 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
-        "defaults": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+        "default-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+            "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "clone": "^1.0.2"
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "default-resolution": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+            "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -1045,12 +1251,6 @@
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
         },
-        "deprecated": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-            "dev": true
-        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1104,6 +1304,28 @@
                 }
             }
         },
+        "duplexify": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "each-props": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+            "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
+            }
+        },
         "easy-extender": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
@@ -1151,12 +1373,23 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-            "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
             "requires": {
-                "once": "~1.3.0"
+                "once": "^1.4.0"
+            },
+            "dependencies": {
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                }
             }
         },
         "engine.io": {
@@ -1225,6 +1458,50 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -1359,6 +1636,23 @@
             "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -1538,12 +1832,6 @@
                 }
             }
         },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-            "dev": true
-        },
         "find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -1555,26 +1843,15 @@
             }
         },
         "findup-sync": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+            "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
             "dev": true,
             "requires": {
                 "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
+                "is-glob": "^4.0.0",
                 "micromatch": "^3.0.4",
                 "resolve-dir": "^1.0.1"
-            },
-            "dependencies": {
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                }
             }
         },
         "fined": {
@@ -1590,17 +1867,21 @@
                 "parse-filepath": "^1.0.1"
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
         "flagged-respawn": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
             "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
             "dev": true
+        },
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
+            }
         },
         "follow-redirects": {
             "version": "1.7.0",
@@ -1684,6 +1965,16 @@
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^3.0.0",
                 "universalify": "^0.1.0"
+            }
+        },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs.realpath": {
@@ -2252,6 +2543,12 @@
                 "rimraf": "2"
             }
         },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
         "gauge": {
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -2274,15 +2571,6 @@
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true
                 }
-            }
-        },
-        "gaze": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-            "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-            "dev": true,
-            "requires": {
-                "globule": "~0.1.0"
             }
         },
         "get-caller-file": {
@@ -2313,26 +2601,17 @@
             }
         },
         "glob": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-            "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "dev": true,
             "requires": {
+                "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
-            },
-            "dependencies": {
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                }
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2393,80 +2672,35 @@
             }
         },
         "glob-stream": {
-            "version": "3.1.18",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+            "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
             "dev": true,
             "requires": {
-                "gaze": "^0.5.1"
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "dev": true,
-            "requires": {
-                "find-index": "^0.1.1"
+                "anymatch": "^2.0.0",
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "is-negated-glob": "^1.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
@@ -2493,58 +2727,6 @@
                 "which": "^1.2.14"
             }
         },
-        "globule": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-            "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-            "dev": true,
-            "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "3.1.21",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-                    "dev": true
-                },
-                "inherits": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                    "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "0.2.14",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
-                    }
-                }
-            }
-        },
         "glogg": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -2567,31 +2749,72 @@
             "dev": true
         },
         "gulp": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-            "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+            "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
+                "glob-watcher": "^5.0.3",
+                "gulp-cli": "^2.2.0",
+                "undertaker": "^1.2.1",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-                    "dev": true
+                "gulp-cli": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+                    "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^3.1.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
                 }
             }
         },
@@ -2945,6 +3168,12 @@
                 "sparkles": "^1.0.0"
             }
         },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
+        },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3254,6 +3483,12 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+            "dev": true
+        },
         "is-number": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3334,6 +3569,12 @@
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
+        "is-valid-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+            "dev": true
+        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3394,6 +3635,12 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3421,11 +3668,36 @@
                 "verror": "1.10.0"
             }
         },
+        "just-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+            "dev": true
+        },
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
             "dev": true
+        },
+        "last-run": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+            "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+            "dev": true,
+            "requires": {
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.5"
+            }
         },
         "lcid": {
             "version": "1.0.0",
@@ -3436,14 +3708,23 @@
                 "invert-kv": "^1.0.0"
             }
         },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "dev": true,
+            "requires": {
+                "flush-write-stream": "^1.0.2"
+            }
+        },
         "liftoff": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+            "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
             "dev": true,
             "requires": {
                 "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
+                "findup-sync": "^3.0.0",
                 "fined": "^1.0.1",
                 "flagged-respawn": "^1.0.0",
                 "is-plain-object": "^2.0.4",
@@ -3674,12 +3955,6 @@
                 "signal-exit": "^3.0.0"
             }
         },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-            "dev": true
-        },
         "make-iterator": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -3708,6 +3983,41 @@
             "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
+            }
+        },
+        "matchdep": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+            "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+            "dev": true,
+            "requires": {
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
+                "stack-trace": "0.0.10"
+            },
+            "dependencies": {
+                "findup-sync": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+                    "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "dev": true,
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^3.1.0",
+                        "micromatch": "^3.0.4",
+                        "resolve-dir": "^1.0.1"
+                    }
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                }
             }
         },
         "math-random": {
@@ -3858,6 +4168,12 @@
                 "duplexer2": "0.0.2"
             }
         },
+        "mute-stdout": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+            "dev": true
+        },
         "nan": {
             "version": "2.13.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
@@ -3883,16 +4199,16 @@
                 "to-regex": "^3.0.1"
             }
         },
-        "natives": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-            "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-            "dev": true
-        },
         "negotiator": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
             "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+            "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
         "node-gyp": {
@@ -4033,6 +4349,15 @@
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
         },
+        "now-and-later": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+            "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.2"
+            }
+        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -4106,6 +4431,12 @@
                 }
             }
         },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
         "object-path": {
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
@@ -4119,6 +4450,18 @@
             "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -4173,6 +4516,16 @@
                 "isobject": "^3.0.1"
             }
         },
+        "object.reduce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+            "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            }
+        },
         "on-finished": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4206,22 +4559,14 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "orchestrator": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+        "ordered-read-streams": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
+                "readable-stream": "^2.0.1"
             }
-        },
-        "ordered-read-streams": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-            "dev": true
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -4577,6 +4922,27 @@
             "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
         },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
+        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -4719,6 +5085,27 @@
                 "safe-regex": "^1.1.0"
             }
         },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "dev": true,
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4751,6 +5138,17 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
             "dev": true
+        },
+        "replace-homedir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+            "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
+            }
         },
         "request": {
             "version": "2.88.0",
@@ -4823,6 +5221,15 @@
             "requires": {
                 "expand-tilde": "^2.0.0",
                 "global-modules": "^1.0.0"
+            }
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
+            "requires": {
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -5004,6 +5411,15 @@
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
             "dev": true
         },
+        "semver-greatest-satisfied-range": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+            "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+            "dev": true,
+            "requires": {
+                "sver-compat": "^1.5.0"
+            }
+        },
         "send": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -5059,12 +5475,6 @@
                     "dev": true
                 }
             }
-        },
-        "sequencify": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-            "dev": true
         },
         "serve-index": {
             "version": "1.9.1",
@@ -5167,12 +5577,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-            "dev": true
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
             "dev": true
         },
         "signal-exit": {
@@ -5510,6 +5914,12 @@
                 "tweetnacl": "~0.14.0"
             }
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -5546,10 +5956,16 @@
                 "readable-stream": "^2.0.1"
             }
         },
-        "stream-consume": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-            "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
+        "stream-exhaust": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+            "dev": true
+        },
+        "stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
         "stream-throttle": {
@@ -5636,6 +6052,16 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "sver-compat": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+            "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "symbol-observable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -5673,13 +6099,14 @@
                 "xtend": "~4.0.1"
             }
         },
-        "tildify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+        "through2-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -5687,6 +6114,16 @@
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
             "dev": true
+        },
+        "to-absolute-glob": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+            "dev": true,
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
+            }
         },
         "to-array": {
             "version": "0.1.4",
@@ -5734,6 +6171,15 @@
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
+            }
+        },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.3"
             }
         },
         "toidentifier": {
@@ -5806,6 +6252,18 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
         "ua-parser-js": {
             "version": "0.7.17",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -5822,6 +6280,29 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
+        },
+        "undertaker": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+            "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
+            }
+        },
+        "undertaker-registry": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
             "dev": true
         },
         "union-value": {
@@ -5860,10 +6341,14 @@
             }
         },
         "unique-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-            "dev": true
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
+            }
         },
         "universalify": {
             "version": "0.1.2",
@@ -5950,12 +6435,6 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
-        "user-home": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-            "dev": true
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5975,12 +6454,12 @@
             "dev": true
         },
         "v8flags": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+            "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
             "dev": true,
             "requires": {
-                "user-home": "^1.1.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -5992,6 +6471,12 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -6052,88 +6537,118 @@
             }
         },
         "vinyl-fs": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
                     "dev": true
                 },
-                "graceful-fs": {
-                    "version": "3.0.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-                    "dev": true,
-                    "requires": {
-                        "natives": "^1.1.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "strip-bom": {
+                "clone-stats": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-                    "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-                    "dev": true,
-                    "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "is-utf8": "^0.2.0"
-                    }
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
                 },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
                 },
                 "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }

--- a/lesson04/assignment/package.json
+++ b/lesson04/assignment/package.json
@@ -10,7 +10,7 @@
     "license": "ISC",
     "devDependencies": {
         "browser-sync": "^2.24.3",
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.2",
         "gulp-autoprefixer": "^4.1.0",
         "gulp-minify-css": "^1.2.4",
         "gulp-plumber": "^1.1.0",

--- a/lesson05/activity/gulpfile.js
+++ b/lesson05/activity/gulpfile.js
@@ -1,13 +1,12 @@
-var gulp = require('gulp'),
+const {dest, series, src, watch} = require('gulp'),
     sass = require('gulp-sass'),
     autoprefix = require('gulp-autoprefixer'),
-    watch = require('gulp-watch'),
     plumber = require('gulp-plumber'),
     gutil = require('gulp-util'),
-    browserSync = require('browser-sync').create();
+    browserSync = require('browser-sync').create()
 
-gulp.task('sass', function() {
-    gulp.src('css/*.scss')
+function compileSass() {
+    return src('css/*.scss')
         .pipe(plumber())
         .pipe(sass())
         .pipe(
@@ -15,22 +14,19 @@ gulp.task('sass', function() {
                 browsers: ['> .5%'],
             })
         )
-        .pipe(gulp.dest('css/'))
+        .pipe(dest('css/'))
         .pipe(browserSync.stream());
-});
+}
 
-gulp.task('watch', function() {
-    gulp.watch('css/*.scss', ['sass']);
-    gulp.watch('*.html').on('change', browserSync.reload);
-});
-
-gulp.task('browser-sync', function() {
+function browserSyncs() {
     browserSync.init({
         notify: false,
         server: {
             baseDir: './',
         },
-    });
-});
+    })
+    watch(['css/*.scss']).on('change', compileSass)
+    watch(['*.html']).on('change', browserSync.reload)
+}
 
-gulp.task('default', ['watch', 'browser-sync']);
+exports.default = browserSyncs

--- a/lesson05/activity/package-lock.json
+++ b/lesson05/activity/package-lock.json
@@ -131,6 +131,15 @@
                 }
             }
         },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "dev": true,
+            "requires": {
+                "buffer-equal": "^1.0.0"
+            }
+        },
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -159,11 +168,29 @@
             "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
             "dev": true
         },
+        "arr-filter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+            "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
+        },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
+        },
+        "arr-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+            "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
         },
         "arr-union": {
             "version": "3.1.0",
@@ -189,11 +216,65 @@
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
+        "array-initial": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+            "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+            "dev": true,
+            "requires": {
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "array-last": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+            "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+            "dev": true,
+            "requires": {
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
         "array-slice": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
             "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
             "dev": true
+        },
+        "array-sort": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+            "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+            "dev": true,
+            "requires": {
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -240,6 +321,18 @@
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
+        "async-done": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+            "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^2.0.0",
+                "stream-exhaust": "^1.0.1"
+            }
+        },
         "async-each": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -263,6 +356,15 @@
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
             "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
+        },
+        "async-settle": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+            "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+            "dev": true,
+            "requires": {
+                "async-done": "^1.2.2"
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -310,6 +412,23 @@
             "requires": {
                 "follow-redirects": "^1.2.5",
                 "is-buffer": "^1.1.5"
+            }
+        },
+        "bach": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+            "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+            "dev": true,
+            "requires": {
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "backo2": {
@@ -591,6 +710,18 @@
             "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
             "dev": true
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
         "bufferstreams": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.0.1.tgz",
@@ -824,6 +955,28 @@
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
+        "collection-map": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+            "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+            "dev": true,
+            "requires": {
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -894,6 +1047,18 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
         "connect": {
             "version": "3.6.6",
             "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -929,6 +1094,15 @@
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -940,6 +1114,16 @@
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
+        },
+        "copy-props": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+            "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+            "dev": true,
+            "requires": {
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -978,6 +1162,16 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1014,13 +1208,36 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
-        "defaults": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+        "default-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+            "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "clone": "^1.0.2"
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "default-resolution": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+            "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -1082,12 +1299,6 @@
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
         },
-        "deprecated": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-            "dev": true
-        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1141,6 +1352,28 @@
                 }
             }
         },
+        "duplexify": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "each-props": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+            "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
+            }
+        },
         "easy-extender": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
@@ -1188,12 +1421,23 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-            "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
             "requires": {
-                "once": "~1.3.0"
+                "once": "^1.4.0"
+            },
+            "dependencies": {
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                }
             }
         },
         "engine.io": {
@@ -1262,6 +1506,50 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -1396,6 +1684,23 @@
             "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -1575,12 +1880,6 @@
                 }
             }
         },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-            "dev": true
-        },
         "find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -1592,26 +1891,17 @@
             }
         },
         "findup-sync": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+            "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
             "dev": true,
             "requires": {
                 "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
+                "is-glob": "^4.0.0",
                 "micromatch": "^3.0.4",
                 "resolve-dir": "^1.0.1"
             },
             "dependencies": {
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -1636,9 +1926,9 @@
             }
         },
         "fined": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
-            "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+            "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
             "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.2",
@@ -1648,17 +1938,21 @@
                 "parse-filepath": "^1.0.1"
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
         "flagged-respawn": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
             "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
             "dev": true
+        },
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
+            }
         },
         "follow-redirects": {
             "version": "1.7.0",
@@ -1744,6 +2038,16 @@
                 "universalify": "^0.1.0"
             }
         },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1770,7 +2074,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -1791,12 +2096,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1811,17 +2118,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1938,7 +2248,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1950,6 +2261,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1964,6 +2276,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1971,12 +2284,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -1995,6 +2310,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2075,7 +2391,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2087,6 +2404,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2172,7 +2490,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2208,6 +2527,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2227,6 +2547,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2270,12 +2591,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -2290,6 +2613,12 @@
                 "mkdirp": ">=0.5 0",
                 "rimraf": "2"
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "gauge": {
             "version": "2.7.4",
@@ -2313,15 +2642,6 @@
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true
                 }
-            }
-        },
-        "gaze": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-            "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-            "dev": true,
-            "requires": {
-                "globule": "~0.1.0"
             }
         },
         "get-caller-file": {
@@ -2352,26 +2672,17 @@
             }
         },
         "glob": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-            "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "dev": true,
             "requires": {
+                "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
-            },
-            "dependencies": {
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                }
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2432,80 +2743,35 @@
             }
         },
         "glob-stream": {
-            "version": "3.1.18",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+            "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
             "dev": true,
             "requires": {
-                "gaze": "^0.5.1"
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "dev": true,
-            "requires": {
-                "find-index": "^0.1.1"
+                "anymatch": "^2.0.0",
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "is-negated-glob": "^1.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
@@ -2532,58 +2798,6 @@
                 "which": "^1.2.14"
             }
         },
-        "globule": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-            "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-            "dev": true,
-            "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "3.1.21",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-                    "dev": true
-                },
-                "inherits": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                    "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "0.2.14",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
-                    }
-                }
-            }
-        },
         "glogg": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -2606,31 +2820,72 @@
             "dev": true
         },
         "gulp": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-            "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+            "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
+                "glob-watcher": "^5.0.3",
+                "gulp-cli": "^2.2.0",
+                "undertaker": "^1.2.1",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-                    "dev": true
+                "gulp-cli": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+                    "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^3.1.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
                 }
             }
         },
@@ -2968,6 +3223,12 @@
                 "sparkles": "^1.0.0"
             }
         },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
+        },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3007,9 +3268,9 @@
             }
         },
         "homedir-polyfill": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-            "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
             "dev": true,
             "requires": {
                 "parse-passwd": "^1.0.0"
@@ -3277,6 +3538,12 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+            "dev": true
+        },
         "is-number": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3357,6 +3624,12 @@
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
+        "is-valid-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+            "dev": true
+        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3417,6 +3690,12 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3444,11 +3723,36 @@
                 "verror": "1.10.0"
             }
         },
+        "just-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+            "dev": true
+        },
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
             "dev": true
+        },
+        "last-run": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+            "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+            "dev": true,
+            "requires": {
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.5"
+            }
         },
         "lcid": {
             "version": "1.0.0",
@@ -3459,14 +3763,23 @@
                 "invert-kv": "^1.0.0"
             }
         },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "dev": true,
+            "requires": {
+                "flush-write-stream": "^1.0.2"
+            }
+        },
         "liftoff": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+            "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
             "dev": true,
             "requires": {
                 "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
+                "findup-sync": "^3.0.0",
                 "fined": "^1.0.1",
                 "flagged-respawn": "^1.0.0",
                 "is-plain-object": "^2.0.4",
@@ -3691,12 +4004,6 @@
                 "signal-exit": "^3.0.0"
             }
         },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-            "dev": true
-        },
         "make-iterator": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -3725,6 +4032,62 @@
             "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
+            }
+        },
+        "matchdep": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+            "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+            "dev": true,
+            "requires": {
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
+                "stack-trace": "0.0.10"
+            },
+            "dependencies": {
+                "findup-sync": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+                    "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "dev": true,
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^3.1.0",
+                        "micromatch": "^3.0.4",
+                        "resolve-dir": "^1.0.1"
+                    }
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                }
             }
         },
         "math-random": {
@@ -3945,6 +4308,12 @@
                 "duplexer2": "0.0.2"
             }
         },
+        "mute-stdout": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+            "dev": true
+        },
         "nan": {
             "version": "2.12.1",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
@@ -3971,16 +4340,16 @@
                 "to-regex": "^3.0.1"
             }
         },
-        "natives": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-            "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-            "dev": true
-        },
         "negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
         "node-gyp": {
@@ -4137,6 +4506,15 @@
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
         },
+        "now-and-later": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+            "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.2"
+            }
+        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -4210,6 +4588,12 @@
                 }
             }
         },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
         "object-path": {
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
@@ -4223,6 +4607,18 @@
             "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -4288,6 +4684,27 @@
                 "isobject": "^3.0.1"
             }
         },
+        "object.reduce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+            "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "on-finished": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4321,22 +4738,14 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "orchestrator": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+        "ordered-read-streams": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
+                "readable-stream": "^2.0.1"
             }
-        },
-        "ordered-read-streams": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-            "dev": true
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -4703,6 +5112,27 @@
             "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
         },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
+        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -4868,6 +5298,27 @@
                 "safe-regex": "^1.1.0"
             }
         },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "dev": true,
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4900,6 +5351,17 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
             "dev": true
+        },
+        "replace-homedir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+            "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
+            }
         },
         "request": {
             "version": "2.88.0",
@@ -4972,6 +5434,15 @@
             "requires": {
                 "expand-tilde": "^2.0.0",
                 "global-modules": "^1.0.0"
+            }
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
+            "requires": {
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -5153,6 +5624,15 @@
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
             "dev": true
         },
+        "semver-greatest-satisfied-range": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+            "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+            "dev": true,
+            "requires": {
+                "sver-compat": "^1.5.0"
+            }
+        },
         "send": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -5208,12 +5688,6 @@
                     "dev": true
                 }
             }
-        },
-        "sequencify": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-            "dev": true
         },
         "serve-index": {
             "version": "1.9.1",
@@ -5316,12 +5790,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-            "dev": true
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
             "dev": true
         },
         "signal-exit": {
@@ -5659,6 +6127,12 @@
                 "tweetnacl": "~0.14.0"
             }
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -5695,10 +6169,16 @@
                 "readable-stream": "^2.0.1"
             }
         },
-        "stream-consume": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-            "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
+        "stream-exhaust": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+            "dev": true
+        },
+        "stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
         "stream-throttle": {
@@ -5785,6 +6265,16 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "sver-compat": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+            "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "symbol-observable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -5822,13 +6312,14 @@
                 "xtend": "~4.0.1"
             }
         },
-        "tildify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+        "through2-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -5836,6 +6327,16 @@
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
             "dev": true
+        },
+        "to-absolute-glob": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+            "dev": true,
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
+            }
         },
         "to-array": {
             "version": "0.1.4",
@@ -5883,6 +6384,15 @@
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
+            }
+        },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.3"
             }
         },
         "toidentifier": {
@@ -5955,6 +6465,18 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
         "ua-parser-js": {
             "version": "0.7.17",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -5971,6 +6493,29 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
+        },
+        "undertaker": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+            "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
+            }
+        },
+        "undertaker-registry": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
             "dev": true
         },
         "union-value": {
@@ -6009,10 +6554,14 @@
             }
         },
         "unique-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-            "dev": true
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
+            }
         },
         "universalify": {
             "version": "0.1.2",
@@ -6099,12 +6648,6 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
-        "user-home": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-            "dev": true
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6124,12 +6667,12 @@
             "dev": true
         },
         "v8flags": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+            "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
             "dev": true,
             "requires": {
-                "user-home": "^1.1.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -6141,6 +6684,12 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -6201,88 +6750,109 @@
             }
         },
         "vinyl-fs": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
                     "dev": true
                 },
-                "graceful-fs": {
-                    "version": "3.0.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-                    "dev": true,
-                    "requires": {
-                        "natives": "^1.1.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "strip-bom": {
+                "clone-stats": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-                    "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-                    "dev": true,
-                    "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "is-utf8": "^0.2.0"
-                    }
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
                 },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
                 },
                 "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }

--- a/lesson05/activity/package.json
+++ b/lesson05/activity/package.json
@@ -10,7 +10,7 @@
     "license": "ISC",
     "devDependencies": {
         "browser-sync": "^2.26.5",
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.2",
         "gulp-autoprefixer": "^6.1.0",
         "gulp-minify-css": "^1.2.4",
         "gulp-plumber": "^1.2.0",

--- a/lesson05/assignment/gulpfile.js
+++ b/lesson05/assignment/gulpfile.js
@@ -1,13 +1,12 @@
-var gulp = require('gulp'),
+const {dest, series, src, watch} = require('gulp'),
     sass = require('gulp-sass'),
     autoprefix = require('gulp-autoprefixer'),
-    watch = require('gulp-watch'),
     plumber = require('gulp-plumber'),
     gutil = require('gulp-util'),
-    browserSync = require('browser-sync').create();
+    browserSync = require('browser-sync').create()
 
-gulp.task('sass', function() {
-    gulp.src('css/*.scss')
+function compileSass() {
+    return src('css/*.scss')
         .pipe(plumber())
         .pipe(sass())
         .pipe(
@@ -15,22 +14,19 @@ gulp.task('sass', function() {
                 browsers: ['> .5%'],
             })
         )
-        .pipe(gulp.dest('css/'))
+        .pipe(dest('css/'))
         .pipe(browserSync.stream());
-});
+}
 
-gulp.task('watch', function() {
-    gulp.watch('css/*.scss', ['sass']);
-    gulp.watch('*.html').on('change', browserSync.reload);
-});
-
-gulp.task('browser-sync', function() {
+function browserSyncs() {
     browserSync.init({
         notify: false,
         server: {
             baseDir: './',
         },
-    });
-});
+    })
+    watch(['css/*.scss']).on('change', compileSass)
+    watch(['*.html']).on('change', browserSync.reload)
+}
 
-gulp.task('default', ['watch', 'browser-sync']);
+exports.default = browserSyncs

--- a/lesson05/assignment/package-lock.json
+++ b/lesson05/assignment/package-lock.json
@@ -131,6 +131,15 @@
                 }
             }
         },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "dev": true,
+            "requires": {
+                "buffer-equal": "^1.0.0"
+            }
+        },
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -159,11 +168,29 @@
             "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
             "dev": true
         },
+        "arr-filter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+            "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
+        },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
+        },
+        "arr-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+            "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+            "dev": true,
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
         },
         "arr-union": {
             "version": "3.1.0",
@@ -189,11 +216,65 @@
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
+        "array-initial": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+            "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+            "dev": true,
+            "requires": {
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "array-last": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+            "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+            "dev": true,
+            "requires": {
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
         "array-slice": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
             "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
             "dev": true
+        },
+        "array-sort": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+            "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+            "dev": true,
+            "requires": {
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -240,6 +321,18 @@
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
+        "async-done": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+            "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^2.0.0",
+                "stream-exhaust": "^1.0.1"
+            }
+        },
         "async-each": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -263,6 +356,15 @@
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
             "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
+        },
+        "async-settle": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+            "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+            "dev": true,
+            "requires": {
+                "async-done": "^1.2.2"
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -310,6 +412,23 @@
             "requires": {
                 "follow-redirects": "^1.2.5",
                 "is-buffer": "^1.1.5"
+            }
+        },
+        "bach": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+            "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+            "dev": true,
+            "requires": {
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "backo2": {
@@ -591,6 +710,18 @@
             "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
             "dev": true
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
         "bufferstreams": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.0.1.tgz",
@@ -824,6 +955,28 @@
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
+        "collection-map": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+            "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+            "dev": true,
+            "requires": {
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -894,6 +1047,18 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
         "connect": {
             "version": "3.6.6",
             "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -929,6 +1094,15 @@
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -940,6 +1114,16 @@
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
+        },
+        "copy-props": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+            "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+            "dev": true,
+            "requires": {
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -978,6 +1162,16 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1014,13 +1208,36 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
-        "defaults": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+        "default-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+            "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "clone": "^1.0.2"
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "default-resolution": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+            "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -1082,12 +1299,6 @@
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
         },
-        "deprecated": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-            "dev": true
-        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1141,6 +1352,28 @@
                 }
             }
         },
+        "duplexify": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "each-props": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+            "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
+            }
+        },
         "easy-extender": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
@@ -1188,12 +1421,23 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-            "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
             "requires": {
-                "once": "~1.3.0"
+                "once": "^1.4.0"
+            },
+            "dependencies": {
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                }
             }
         },
         "engine.io": {
@@ -1262,6 +1506,50 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -1396,6 +1684,23 @@
             "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -1575,12 +1880,6 @@
                 }
             }
         },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-            "dev": true
-        },
         "find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -1592,26 +1891,17 @@
             }
         },
         "findup-sync": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+            "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
             "dev": true,
             "requires": {
                 "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
+                "is-glob": "^4.0.0",
                 "micromatch": "^3.0.4",
                 "resolve-dir": "^1.0.1"
             },
             "dependencies": {
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -1636,9 +1926,9 @@
             }
         },
         "fined": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
-            "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+            "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
             "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.2",
@@ -1648,17 +1938,21 @@
                 "parse-filepath": "^1.0.1"
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
         "flagged-respawn": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
             "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
             "dev": true
+        },
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
+            }
         },
         "follow-redirects": {
             "version": "1.7.0",
@@ -1744,6 +2038,16 @@
                 "universalify": "^0.1.0"
             }
         },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1770,7 +2074,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -1791,12 +2096,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1811,17 +2118,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1938,7 +2248,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1950,6 +2261,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1964,6 +2276,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1971,12 +2284,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -1995,6 +2310,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2075,7 +2391,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2087,6 +2404,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2172,7 +2490,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2208,6 +2527,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2227,6 +2547,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2270,12 +2591,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -2290,6 +2613,12 @@
                 "mkdirp": ">=0.5 0",
                 "rimraf": "2"
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "gauge": {
             "version": "2.7.4",
@@ -2313,15 +2642,6 @@
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true
                 }
-            }
-        },
-        "gaze": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-            "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-            "dev": true,
-            "requires": {
-                "globule": "~0.1.0"
             }
         },
         "get-caller-file": {
@@ -2352,26 +2672,17 @@
             }
         },
         "glob": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-            "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "dev": true,
             "requires": {
+                "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
-            },
-            "dependencies": {
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                }
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2432,80 +2743,35 @@
             }
         },
         "glob-stream": {
-            "version": "3.1.18",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.0.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+            "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
             "dev": true,
             "requires": {
-                "gaze": "^0.5.1"
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "dev": true,
-            "requires": {
-                "find-index": "^0.1.1"
+                "anymatch": "^2.0.0",
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "is-negated-glob": "^1.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
@@ -2532,58 +2798,6 @@
                 "which": "^1.2.14"
             }
         },
-        "globule": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-            "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-            "dev": true,
-            "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "3.1.21",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-                    "dev": true
-                },
-                "inherits": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                    "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "0.2.14",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
-                    }
-                }
-            }
-        },
         "glogg": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -2606,31 +2820,72 @@
             "dev": true
         },
         "gulp": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-            "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+            "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
+                "glob-watcher": "^5.0.3",
+                "gulp-cli": "^2.2.0",
+                "undertaker": "^1.2.1",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-                    "dev": true
+                "gulp-cli": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+                    "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^3.1.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
                 }
             }
         },
@@ -2968,6 +3223,12 @@
                 "sparkles": "^1.0.0"
             }
         },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
+        },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3007,9 +3268,9 @@
             }
         },
         "homedir-polyfill": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-            "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
             "dev": true,
             "requires": {
                 "parse-passwd": "^1.0.0"
@@ -3277,6 +3538,12 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+            "dev": true
+        },
         "is-number": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3357,6 +3624,12 @@
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
+        "is-valid-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+            "dev": true
+        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3417,6 +3690,12 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3444,11 +3723,36 @@
                 "verror": "1.10.0"
             }
         },
+        "just-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+            "dev": true
+        },
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
             "dev": true
+        },
+        "last-run": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+            "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+            "dev": true,
+            "requires": {
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.5"
+            }
         },
         "lcid": {
             "version": "1.0.0",
@@ -3459,14 +3763,23 @@
                 "invert-kv": "^1.0.0"
             }
         },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "dev": true,
+            "requires": {
+                "flush-write-stream": "^1.0.2"
+            }
+        },
         "liftoff": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+            "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
             "dev": true,
             "requires": {
                 "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
+                "findup-sync": "^3.0.0",
                 "fined": "^1.0.1",
                 "flagged-respawn": "^1.0.0",
                 "is-plain-object": "^2.0.4",
@@ -3691,12 +4004,6 @@
                 "signal-exit": "^3.0.0"
             }
         },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-            "dev": true
-        },
         "make-iterator": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -3725,6 +4032,62 @@
             "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
+            }
+        },
+        "matchdep": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+            "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+            "dev": true,
+            "requires": {
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
+                "stack-trace": "0.0.10"
+            },
+            "dependencies": {
+                "findup-sync": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+                    "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "dev": true,
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^3.1.0",
+                        "micromatch": "^3.0.4",
+                        "resolve-dir": "^1.0.1"
+                    }
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                }
             }
         },
         "math-random": {
@@ -3945,6 +4308,12 @@
                 "duplexer2": "0.0.2"
             }
         },
+        "mute-stdout": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+            "dev": true
+        },
         "nan": {
             "version": "2.12.1",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
@@ -3971,16 +4340,16 @@
                 "to-regex": "^3.0.1"
             }
         },
-        "natives": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-            "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-            "dev": true
-        },
         "negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
         "node-gyp": {
@@ -4137,6 +4506,15 @@
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
         },
+        "now-and-later": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+            "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.2"
+            }
+        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -4210,6 +4588,12 @@
                 }
             }
         },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
         "object-path": {
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
@@ -4223,6 +4607,18 @@
             "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -4288,6 +4684,27 @@
                 "isobject": "^3.0.1"
             }
         },
+        "object.reduce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+            "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "on-finished": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4321,22 +4738,14 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "orchestrator": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+        "ordered-read-streams": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
+                "readable-stream": "^2.0.1"
             }
-        },
-        "ordered-read-streams": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-            "dev": true
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -4703,6 +5112,27 @@
             "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
         },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
+        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -4868,6 +5298,27 @@
                 "safe-regex": "^1.1.0"
             }
         },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "dev": true,
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4900,6 +5351,17 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
             "dev": true
+        },
+        "replace-homedir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+            "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
+            }
         },
         "request": {
             "version": "2.88.0",
@@ -4972,6 +5434,15 @@
             "requires": {
                 "expand-tilde": "^2.0.0",
                 "global-modules": "^1.0.0"
+            }
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
+            "requires": {
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -5153,6 +5624,15 @@
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
             "dev": true
         },
+        "semver-greatest-satisfied-range": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+            "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+            "dev": true,
+            "requires": {
+                "sver-compat": "^1.5.0"
+            }
+        },
         "send": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -5208,12 +5688,6 @@
                     "dev": true
                 }
             }
-        },
-        "sequencify": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-            "dev": true
         },
         "serve-index": {
             "version": "1.9.1",
@@ -5316,12 +5790,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-            "dev": true
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
             "dev": true
         },
         "signal-exit": {
@@ -5659,6 +6127,12 @@
                 "tweetnacl": "~0.14.0"
             }
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -5695,10 +6169,16 @@
                 "readable-stream": "^2.0.1"
             }
         },
-        "stream-consume": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-            "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
+        "stream-exhaust": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+            "dev": true
+        },
+        "stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
         "stream-throttle": {
@@ -5785,6 +6265,16 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "sver-compat": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+            "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "symbol-observable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -5822,13 +6312,14 @@
                 "xtend": "~4.0.1"
             }
         },
-        "tildify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+        "through2-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -5836,6 +6327,16 @@
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
             "dev": true
+        },
+        "to-absolute-glob": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+            "dev": true,
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
+            }
         },
         "to-array": {
             "version": "0.1.4",
@@ -5883,6 +6384,15 @@
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
+            }
+        },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.3"
             }
         },
         "toidentifier": {
@@ -5955,6 +6465,18 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
         "ua-parser-js": {
             "version": "0.7.17",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -5971,6 +6493,29 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
+        },
+        "undertaker": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+            "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
+            }
+        },
+        "undertaker-registry": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
             "dev": true
         },
         "union-value": {
@@ -6009,10 +6554,14 @@
             }
         },
         "unique-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-            "dev": true
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
+            }
         },
         "universalify": {
             "version": "0.1.2",
@@ -6099,12 +6648,6 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
-        "user-home": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-            "dev": true
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6124,12 +6667,12 @@
             "dev": true
         },
         "v8flags": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+            "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
             "dev": true,
             "requires": {
-                "user-home": "^1.1.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -6141,6 +6684,12 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -6201,88 +6750,109 @@
             }
         },
         "vinyl-fs": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
                     "dev": true
                 },
-                "graceful-fs": {
-                    "version": "3.0.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-                    "dev": true,
-                    "requires": {
-                        "natives": "^1.1.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "strip-bom": {
+                "clone-stats": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-                    "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-                    "dev": true,
-                    "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "is-utf8": "^0.2.0"
-                    }
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
                 },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
                 },
                 "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }

--- a/lesson05/assignment/package.json
+++ b/lesson05/assignment/package.json
@@ -10,7 +10,7 @@
     "license": "ISC",
     "devDependencies": {
         "browser-sync": "^2.26.5",
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.2",
         "gulp-autoprefixer": "^6.1.0",
         "gulp-minify-css": "^1.2.4",
         "gulp-plumber": "^1.2.0",


### PR DESCRIPTION
For review immediately: README documentation. 

This version of Gulp runs fine with npm v 13.x. However, there is a problem with Node-sass with this version, which is still solved by using npm v10.x. So, updating Gulp is not enough.